### PR TITLE
Separation of suply and fees(which include excess funds)

### DIFF
--- a/ethereum/contracts/Bridge.sol
+++ b/ethereum/contracts/Bridge.sol
@@ -241,7 +241,8 @@ contract Bridge is AccessControl {
      * @return targetAddress : address to send tokens to
      */
     function getFeesAccrued() public view returns(uint256) {
-        return _feesAccrued();
+        // NOTE(pb): This subtraction shall NEVER fail:
+        return token.balanceOf(address(this)).sub(supply, "Critical err: balance < supply");
     }
 
 
@@ -560,7 +561,7 @@ contract Bridge is AccessControl {
         public
         onlyOwner
     {
-        uint256 fees = _feesAccrued();
+        uint256 fees = getFeesAccrued();
         require(fees > 0, "No fees to withdraw");
         token.transfer(targetAddress, fees);
         emit FeesWithdrawal(targetAddress, fees);
@@ -628,11 +629,5 @@ contract Bridge is AccessControl {
     {
         cap = cap_;
         emit CapUpdate(cap);
-    }
-
-
-    function _feesAccrued() internal view returns(uint256) {
-        // NOTE(pb): This subtraction shall NEVER fail:
-        return token.balanceOf(address(this)).sub(supply, "Critical err: balance < supply");
     }
 }


### PR DESCRIPTION
This change separates accrued swap fees from contract supply, what allows clean withdrawal of the fees from the contract.
The advantage of this change is *sparing* cca. ~20K [gas] for `refund(...)` operation (see comparison of the the gas profiles bellow).

There is small disadvantage - it is not possible to separate accrued swap fees from *excess funds*(= unsolicited funds transfers, which were sent to address of the Bridge contract directly via `ERC20.transfer(...)`).
**Thus, *excess funds* are treated as swap fees in the current contract design.**
This is not an issue at all, since excess funds are unsolicited tranfers sent by users by their own mistake. They are not going to affect Birdge contract `supply` state variable which is, by design, invariant to swap fees and excess funds.

If necessary, excess funds can be identified off-chain, by querying relevant events from Bridge and FET-ERC20 contracts and performing reconciliation.

```txt
===============================
========  C U R R E N T  ======
---------  Gas Profile  -------
Bridge <Contract>
   ├─ constructor    -  avg: 2429102  low: 2429079  high: 2429174
   ├─ grantRole      -  avg:   89187  low:   89187  high:   89187
   ├─ swap           -  avg:   61716  low:   23962  high:   81489
   ├─ refund         -  avg:   55022  low:   24454  high:   73039
   ├─ mint           -  avg:   44811  low:   44481  high:   45141
   ├─ reverseSwap    -  avg:   43038  low:   26420  high:   53898
   ├─ refundInFull   -  avg:   40543  low:   40543  high:   40543
   ├─ deposit        -  avg:   30645  low:   22800  high:   44546
   ├─ withdraw       -  avg:   29062  low:   23178  high:   46716
   ├─ pauseSince     -  avg:   28679  low:   24977  high:   31010
   ├─ withdrawFees   -  avg:   28340  low:   22992  high:   44386
   ├─ burn           -  avg:   28318  low:   22883  high:   44624
   ├─ setLimits      -  avg:   26600  low:   23115  high:   39918
   ├─ setCap         -  avg:   25188  low:   22807  high:   28773
   ├─ deleteContract -  avg:   23270  low:   22969  high:   24175
   └─ newRelayEon    -  avg:   20556  low:   14691  high:   22511
FetERC20Mock <Contract>
   ├─ constructor    -  avg:  985663  low:  985663  high:  985663
   ├─ transfer       -  avg:   51204  low:   51139  high:   51211
   └─ approve        -  avg:   44081  low:   44034  high:   44094
----  26 passed in 50.71s  ----

===============================
=========  B E F O R E  =======
---------  Gas Profile  -------
Bridge <Contract>
   ├─ constructor         -  avg: 2469207  low: 2469184  high: 2469279
   ├─ grantRole           -  avg:   89165  low:   89165  high:   89165
   ├─ refund              -  avg:   72231  low:   24454  high:   94735
   ├─ swap                -  avg:   63451  low:   23984  high:   81511
   ├─ withdrawExcessFunds -  avg:   45478  low:   45478  high:   45478
   ├─ mint                -  avg:   44811  low:   44481  high:   45141
   ├─ refundInFull        -  avg:   40541  low:   40541  high:   40541
   ├─ reverseSwap         -  avg:   36186  low:   26420  high:   53898
   ├─ deposit             -  avg:   30645  low:   22800  high:   44546
   ├─ withdraw            -  avg:   29065  low:   23178  high:   46728
   ├─ pauseSince          -  avg:   28657  low:   24955  high:   30988
   ├─ burn                -  avg:   28299  low:   22861  high:   44614
   ├─ setLimits           -  avg:   27640  low:   23056  high:   39668
   ├─ withdrawRefundsFees -  avg:   25530  low:   23035  high:   33016
   ├─ setCap              -  avg:   25218  low:   22823  high:   28837
   ├─ deleteContract      -  avg:   23328  low:   23036  high:   24209
   └─ newRelayEon         -  avg:   20575  low:   14702  high:   22533
FetERC20Mock <Contract>
   ├─ constructor         -  avg:  985663  low:  985663  high:  985663
   ├─ transfer            -  avg:   51031  low:   36151  high:   51211
   └─ approve             -  avg:   44093  low:   44046  high:   44106
----  29 passed in 57.65s  ----
```