### PR TITLE
[Eth]: Expose AccessControl contract as interface

### DIFF
--- a/ethereum/build/interfaces/IAccessControl.json
+++ b/ethereum/build/interfaces/IAccessControl.json
@@ -1,0 +1,1243 @@
+{
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getRoleMember",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleMemberCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "ast": {
+    "absolutePath": "interfaces/IAccessControl.sol",
+    "exportedSymbols": {
+      "IAccessControl": [
+        90
+      ]
+    },
+    "id": 91,
+    "license": "Apache-2.0",
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 1,
+        "literals": [
+          "solidity",
+          "^",
+          "0.6",
+          ".0",
+          "||",
+          "^",
+          "0.7",
+          ".0"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "820:33:0"
+      },
+      {
+        "abstract": false,
+        "baseContracts": [],
+        "contractDependencies": [],
+        "contractKind": "interface",
+        "documentation": {
+          "id": 2,
+          "nodeType": "StructuredDocumentation",
+          "src": "856:72:0",
+          "text": " @title Interface for AccessControl contract from OpenZeppelin"
+        },
+        "fullyImplemented": false,
+        "id": 90,
+        "linearizedBaseContracts": [
+          90
+        ],
+        "name": "IAccessControl",
+        "nodeType": "ContractDefinition",
+        "nodes": [
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 3,
+              "nodeType": "StructuredDocumentation",
+              "src": "961:292:0",
+              "text": " @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`\n `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite\n {RoleAdminChanged} not being emitted signaling this.\n _Available since v3.1._"
+            },
+            "id": 11,
+            "name": "RoleAdminChanged",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 10,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 5,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 11,
+                  "src": "1281:20:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 4,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1281:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 7,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "previousAdminRole",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 11,
+                  "src": "1303:33:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 6,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1303:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 9,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "newAdminRole",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 11,
+                  "src": "1338:28:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 8,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1338:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1280:87:0"
+            },
+            "src": "1258:110:0"
+          },
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 12,
+              "nodeType": "StructuredDocumentation",
+              "src": "1374:198:0",
+              "text": " @dev Emitted when `account` is granted `role`.\n `sender` is the account that originated the contract call, an admin role\n bearer except when using {_setupRole}."
+            },
+            "id": 20,
+            "name": "RoleGranted",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 19,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 14,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 20,
+                  "src": "1595:20:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 13,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1595:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 16,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "account",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 20,
+                  "src": "1617:23:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 15,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1617:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 18,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "sender",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 20,
+                  "src": "1642:22:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 17,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1642:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1594:71:0"
+            },
+            "src": "1577:89:0"
+          },
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 21,
+              "nodeType": "StructuredDocumentation",
+              "src": "1672:275:0",
+              "text": " @dev Emitted when `account` is revoked `role`.\n `sender` is the account that originated the contract call:\n   - if using `revokeRole`, it is the admin role bearer\n   - if using `renounceRole`, it is the role bearer (i.e. `account`)"
+            },
+            "id": 29,
+            "name": "RoleRevoked",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 28,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 23,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 29,
+                  "src": "1970:20:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 22,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1970:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 25,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "account",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 29,
+                  "src": "1992:23:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 24,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1992:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 27,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "sender",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 29,
+                  "src": "2017:22:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 26,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2017:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1969:71:0"
+            },
+            "src": "1952:89:0"
+          },
+          {
+            "documentation": {
+              "id": 30,
+              "nodeType": "StructuredDocumentation",
+              "src": "2047:76:0",
+              "text": " @dev Returns `true` if `account` has been granted `role`."
+            },
+            "functionSelector": "91d14854",
+            "id": 39,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "hasRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 35,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 32,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 39,
+                  "src": "2145:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 31,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2145:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 34,
+                  "mutability": "mutable",
+                  "name": "account",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 39,
+                  "src": "2159:15:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 33,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2159:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2144:31:0"
+            },
+            "returnParameters": {
+              "id": 38,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 37,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 39,
+                  "src": "2199:4:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  },
+                  "typeName": {
+                    "id": 36,
+                    "name": "bool",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2199:4:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2198:6:0"
+            },
+            "scope": 90,
+            "src": "2128:77:0",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "documentation": {
+              "id": 40,
+              "nodeType": "StructuredDocumentation",
+              "src": "2211:157:0",
+              "text": " @dev Returns the number of accounts that have `role`. Can be used\n together with {getRoleMember} to enumerate all bearers of a role."
+            },
+            "functionSelector": "ca15c873",
+            "id": 47,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getRoleMemberCount",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 43,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 42,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 47,
+                  "src": "2401:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 41,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2401:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2400:14:0"
+            },
+            "returnParameters": {
+              "id": 46,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 45,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 47,
+                  "src": "2438:7:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 44,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2438:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2437:9:0"
+            },
+            "scope": 90,
+            "src": "2373:74:0",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "documentation": {
+              "id": 48,
+              "nodeType": "StructuredDocumentation",
+              "src": "2453:574:0",
+              "text": " @dev Returns one of the accounts that have `role`. `index` must be a\n value between 0 and {getRoleMemberCount}, non-inclusive.\n Role bearers are not sorted in any particular way, and their ordering may\n change at any point.\n WARNING: When using {getRoleMember} and {getRoleMemberCount}, make sure\n you perform all queries on the same block. See the following\n https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296[forum post]\n for more information."
+            },
+            "functionSelector": "9010d07c",
+            "id": 57,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getRoleMember",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 53,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 50,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 57,
+                  "src": "3055:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 49,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3055:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 52,
+                  "mutability": "mutable",
+                  "name": "index",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 57,
+                  "src": "3069:13:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 51,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3069:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3054:29:0"
+            },
+            "returnParameters": {
+              "id": 56,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 55,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 57,
+                  "src": "3107:7:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 54,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3107:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3106:9:0"
+            },
+            "scope": 90,
+            "src": "3032:84:0",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "documentation": {
+              "id": 58,
+              "nodeType": "StructuredDocumentation",
+              "src": "3122:170:0",
+              "text": " @dev Returns the admin role that controls `role`. See {grantRole} and\n {revokeRole}.\n To change a role's admin, use {_setRoleAdmin}."
+            },
+            "functionSelector": "248a9ca3",
+            "id": 65,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getRoleAdmin",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 61,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 60,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 65,
+                  "src": "3319:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 59,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3319:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3318:14:0"
+            },
+            "returnParameters": {
+              "id": 64,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 63,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 65,
+                  "src": "3356:7:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 62,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3356:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3355:9:0"
+            },
+            "scope": 90,
+            "src": "3297:68:0",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "documentation": {
+              "id": 66,
+              "nodeType": "StructuredDocumentation",
+              "src": "3371:239:0",
+              "text": " @dev Grants `role` to `account`.\n If `account` had not been already granted `role`, emits a {RoleGranted}\n event.\n Requirements:\n - the caller must have ``role``'s admin role."
+            },
+            "functionSelector": "2f2ff15d",
+            "id": 73,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "grantRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 71,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 68,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 73,
+                  "src": "3634:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 67,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3634:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 70,
+                  "mutability": "mutable",
+                  "name": "account",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 73,
+                  "src": "3648:15:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 69,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3648:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3633:31:0"
+            },
+            "returnParameters": {
+              "id": 72,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3673:0:0"
+            },
+            "scope": 90,
+            "src": "3615:59:0",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "documentation": {
+              "id": 74,
+              "nodeType": "StructuredDocumentation",
+              "src": "3680:223:0",
+              "text": " @dev Revokes `role` from `account`.\n If `account` had been granted `role`, emits a {RoleRevoked} event.\n Requirements:\n - the caller must have ``role``'s admin role."
+            },
+            "functionSelector": "d547741f",
+            "id": 81,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "revokeRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 79,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 76,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 81,
+                  "src": "3928:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 75,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3928:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 78,
+                  "mutability": "mutable",
+                  "name": "account",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 81,
+                  "src": "3942:15:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 77,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3942:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3927:31:0"
+            },
+            "returnParameters": {
+              "id": 80,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3967:0:0"
+            },
+            "scope": 90,
+            "src": "3908:60:0",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "documentation": {
+              "id": 82,
+              "nodeType": "StructuredDocumentation",
+              "src": "3974:480:0",
+              "text": " @dev Revokes `role` from the calling account.\n Roles are often managed via {grantRole} and {revokeRole}: this function's\n purpose is to provide a mechanism for accounts to lose their privileges\n if they are compromised (such as when a trusted device is misplaced).\n If the calling account had been granted `role`, emits a {RoleRevoked}\n event.\n Requirements:\n - the caller must be `account`."
+            },
+            "functionSelector": "36568abe",
+            "id": 89,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "renounceRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 87,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 84,
+                  "mutability": "mutable",
+                  "name": "role",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 89,
+                  "src": "4481:12:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 83,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4481:7:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 86,
+                  "mutability": "mutable",
+                  "name": "account",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 89,
+                  "src": "4495:15:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 85,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4495:7:0",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "4480:31:0"
+            },
+            "returnParameters": {
+              "id": 88,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "4520:0:0"
+            },
+            "scope": 90,
+            "src": "4459:62:0",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "external"
+          }
+        ],
+        "scope": 91,
+        "src": "929:3594:0"
+      }
+    ],
+    "src": "820:3704:0"
+  },
+  "contractName": "IAccessControl",
+  "dependencies": [],
+  "offset": [
+    929,
+    4523
+  ],
+  "sha1": "35f4235bc7a3670a350ac3516b7715d02a8c0761",
+  "source": "// SPDX-License-Identifier:Apache-2.0\n//------------------------------------------------------------------------------\n//\n//   Copyright 2021 Fetch.AI Limited\n//\n//   Licensed under the Apache License, Version 2.0 (the \"License\");\n//   you may not use this file except in compliance with the License.\n//   You may obtain a copy of the License at\n//\n//       http://www.apache.org/licenses/LICENSE-2.0\n//\n//   Unless required by applicable law or agreed to in writing, software\n//   distributed under the License is distributed on an \"AS IS\" BASIS,\n//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n//   See the License for the specific language governing permissions and\n//   limitations under the License.\n//\n//------------------------------------------------------------------------------\n\npragma solidity ^0.6.0 || ^0.7.0;\n\n\n/**\n * @title Interface for AccessControl contract from OpenZeppelin\n */\ninterface IAccessControl {\n\n    /**\n     * @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`\n     *\n     * `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite\n     * {RoleAdminChanged} not being emitted signaling this.\n     *\n     * _Available since v3.1._\n     */\n    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);\n\n    /**\n     * @dev Emitted when `account` is granted `role`.\n     *\n     * `sender` is the account that originated the contract call, an admin role\n     * bearer except when using {_setupRole}.\n     */\n    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);\n\n    /**\n     * @dev Emitted when `account` is revoked `role`.\n     *\n     * `sender` is the account that originated the contract call:\n     *   - if using `revokeRole`, it is the admin role bearer\n     *   - if using `renounceRole`, it is the role bearer (i.e. `account`)\n     */\n    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);\n\n    /**\n     * @dev Returns `true` if `account` has been granted `role`.\n     */\n    function hasRole(bytes32 role, address account) external view returns (bool);\n\n    /**\n     * @dev Returns the number of accounts that have `role`. Can be used\n     * together with {getRoleMember} to enumerate all bearers of a role.\n     */\n    function getRoleMemberCount(bytes32 role) external view returns (uint256);\n\n    /**\n     * @dev Returns one of the accounts that have `role`. `index` must be a\n     * value between 0 and {getRoleMemberCount}, non-inclusive.\n     *\n     * Role bearers are not sorted in any particular way, and their ordering may\n     * change at any point.\n     *\n     * WARNING: When using {getRoleMember} and {getRoleMemberCount}, make sure\n     * you perform all queries on the same block. See the following\n     * https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296[forum post]\n     * for more information.\n     */\n    function getRoleMember(bytes32 role, uint256 index) external view returns (address);\n\n    /**\n     * @dev Returns the admin role that controls `role`. See {grantRole} and\n     * {revokeRole}.\n     *\n     * To change a role's admin, use {_setRoleAdmin}.\n     */\n    function getRoleAdmin(bytes32 role) external view returns (bytes32);\n\n    /**\n     * @dev Grants `role` to `account`.\n     *\n     * If `account` had not been already granted `role`, emits a {RoleGranted}\n     * event.\n     *\n     * Requirements:\n     *\n     * - the caller must have ``role``'s admin role.\n     */\n    function grantRole(bytes32 role, address account) external;\n\n    /**\n     * @dev Revokes `role` from `account`.\n     *\n     * If `account` had been granted `role`, emits a {RoleRevoked} event.\n     *\n     * Requirements:\n     *\n     * - the caller must have ``role``'s admin role.\n     */\n    function revokeRole(bytes32 role, address account) external;\n\n    /**\n     * @dev Revokes `role` from the calling account.\n     *\n     * Roles are often managed via {grantRole} and {revokeRole}: this function's\n     * purpose is to provide a mechanism for accounts to lose their privileges\n     * if they are compromised (such as when a trusted device is misplaced).\n     *\n     * If the calling account had been granted `role`, emits a {RoleRevoked}\n     * event.\n     *\n     * Requirements:\n     *\n     * - the caller must be `account`.\n     */\n    function renounceRole(bytes32 role, address account) external;\n}\n",
+  "type": "interface"
+}

--- a/ethereum/build/interfaces/IBridge.json
+++ b/ethereum/build/interfaces/IBridge.json
@@ -825,30 +825,30 @@
     "absolutePath": "interfaces/IBridge.sol",
     "exportedSymbols": {
       "IBridge": [
-        12
+        103
       ],
       "IBridgeAdmin": [
-        94
+        185
       ],
       "IBridgeCommon": [
-        277
+        368
       ],
       "IBridgeMonitor": [
-        296
+        387
       ],
       "IBridgePublic": [
-        311
+        402
       ],
       "IBridgeRelayer": [
-        362
+        453
       ]
     },
-    "id": 13,
+    "id": 104,
     "license": "Apache-2.0",
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 1,
+        "id": 92,
         "literals": [
           "solidity",
           "^",
@@ -860,38 +860,38 @@
           ".0"
         ],
         "nodeType": "PragmaDirective",
-        "src": "820:33:0"
+        "src": "820:33:1"
       },
       {
         "absolutePath": "interfaces/IBridgePublic.sol",
         "file": "./IBridgePublic.sol",
-        "id": 2,
+        "id": 93,
         "nodeType": "ImportDirective",
-        "scope": 13,
-        "sourceUnit": 312,
-        "src": "855:29:0",
+        "scope": 104,
+        "sourceUnit": 403,
+        "src": "855:29:1",
         "symbolAliases": [],
         "unitAlias": ""
       },
       {
         "absolutePath": "interfaces/IBridgeRelayer.sol",
         "file": "./IBridgeRelayer.sol",
-        "id": 3,
+        "id": 94,
         "nodeType": "ImportDirective",
-        "scope": 13,
-        "sourceUnit": 363,
-        "src": "885:30:0",
+        "scope": 104,
+        "sourceUnit": 454,
+        "src": "885:30:1",
         "symbolAliases": [],
         "unitAlias": ""
       },
       {
         "absolutePath": "interfaces/IBridgeAdmin.sol",
         "file": "./IBridgeAdmin.sol",
-        "id": 4,
+        "id": 95,
         "nodeType": "ImportDirective",
-        "scope": 13,
-        "sourceUnit": 95,
-        "src": "916:28:0",
+        "scope": 104,
+        "sourceUnit": 186,
+        "src": "916:28:1",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -900,85 +900,85 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 6,
+              "id": 97,
               "name": "IBridgePublic",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 311,
-              "src": "2841:13:0",
+              "referencedDeclaration": 402,
+              "src": "2841:13:1",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgePublic_$311",
+                "typeIdentifier": "t_contract$_IBridgePublic_$402",
                 "typeString": "contract IBridgePublic"
               }
             },
-            "id": 7,
+            "id": 98,
             "nodeType": "InheritanceSpecifier",
-            "src": "2841:13:0"
+            "src": "2841:13:1"
           },
           {
             "baseName": {
-              "id": 8,
+              "id": 99,
               "name": "IBridgeRelayer",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 362,
-              "src": "2856:14:0",
+              "referencedDeclaration": 453,
+              "src": "2856:14:1",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeRelayer_$362",
+                "typeIdentifier": "t_contract$_IBridgeRelayer_$453",
                 "typeString": "contract IBridgeRelayer"
               }
             },
-            "id": 9,
+            "id": 100,
             "nodeType": "InheritanceSpecifier",
-            "src": "2856:14:0"
+            "src": "2856:14:1"
           },
           {
             "baseName": {
-              "id": 10,
+              "id": 101,
               "name": "IBridgeAdmin",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 94,
-              "src": "2872:12:0",
+              "referencedDeclaration": 185,
+              "src": "2872:12:1",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeAdmin_$94",
+                "typeIdentifier": "t_contract$_IBridgeAdmin_$185",
                 "typeString": "contract IBridgeAdmin"
               }
             },
-            "id": 11,
+            "id": 102,
             "nodeType": "InheritanceSpecifier",
-            "src": "2872:12:0"
+            "src": "2872:12:1"
           }
         ],
         "contractDependencies": [
-          94,
-          277,
-          296,
-          311,
-          362
+          185,
+          368,
+          387,
+          402,
+          453
         ],
         "contractKind": "interface",
         "documentation": {
-          "id": 5,
+          "id": 96,
           "nodeType": "StructuredDocumentation",
-          "src": "947:1872:0",
+          "src": "947:1872:1",
           "text": " @title Bi-directional bridge for transferring FET tokens between Ethereum and Fetch Mainnet-v2\n @notice This bridge allows to transfer [ERC20-FET] tokens from Ethereum Mainnet to [Native FET] tokens on Fetch\n         Native Mainnet-v2 and **other way around** (= it is bi-directional).\n         User will be *charged* swap fee defined in counterpart contract deployed on Fetch Native Mainnet-v2.\n         In the case of a refund, user will be charged a swap fee configured in this contract.\n @dev There are three primary actions defining business logic of this contract:\n       * `swap(...)`: initiates swap of tokens from Ethereum to Fetch Native Mainnet-v2, callable by anyone (= users)\n       * `reverseSwap(...)`: finalises the swap of tokens in *opposite* direction = receives swap originally\n                             initiated on Fetch Native Mainnet-v2, callable exclusively by `relayer` role\n       * `refund(...)`: refunds swap originally initiated in this contract(by `swap(...)` call), callable exclusively\n                        by `relayer` role\n      Swap Fees for `swap(...)` operations (direction from this contract to are handled by the counterpart contract on Fetch Native Mainnet-v2, **except** for refunds, for\n      which user is charged swap fee defined by this contract (since relayer needs to send refund transaction back to\n      this contract.\n      ! IMPORTANT !: Current design of this contract does *NOT* allow to distinguish between *swap fees accrued* and\n      *excess funds* sent to the address of this contract via *direct* `ERC20.transfer(...)`.\n      Implication is, that excess funds **are treated** as swap fees.\n      The only way how to separate these two is to do it *off-chain*, by replaying events from this and FET ERC20\n      contracts, and do the reconciliation."
         },
         "fullyImplemented": false,
-        "id": 12,
+        "id": 103,
         "linearizedBaseContracts": [
-          12,
-          94,
-          296,
-          362,
-          311,
-          277
+          103,
+          185,
+          387,
+          453,
+          402,
+          368
         ],
         "name": "IBridge",
         "nodeType": "ContractDefinition",
         "nodes": [],
-        "scope": 13,
-        "src": "2820:67:0"
+        "scope": 104,
+        "src": "2820:67:1"
       }
     ],
-    "src": "820:2068:0"
+    "src": "820:2068:1"
   },
   "contractName": "IBridge",
   "dependencies": [

--- a/ethereum/build/interfaces/IBridgeAdmin.json
+++ b/ethereum/build/interfaces/IBridgeAdmin.json
@@ -706,21 +706,21 @@
     "absolutePath": "interfaces/IBridgeAdmin.sol",
     "exportedSymbols": {
       "IBridgeAdmin": [
-        94
+        185
       ],
       "IBridgeCommon": [
-        277
+        368
       ],
       "IBridgeMonitor": [
-        296
+        387
       ]
     },
-    "id": 95,
+    "id": 186,
     "license": "Apache-2.0",
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 14,
+        "id": 105,
         "literals": [
           "solidity",
           "^",
@@ -732,27 +732,27 @@
           ".0"
         ],
         "nodeType": "PragmaDirective",
-        "src": "820:33:1"
+        "src": "820:33:2"
       },
       {
         "absolutePath": "interfaces/IBridgeCommon.sol",
         "file": "./IBridgeCommon.sol",
-        "id": 15,
+        "id": 106,
         "nodeType": "ImportDirective",
-        "scope": 95,
-        "sourceUnit": 278,
-        "src": "855:29:1",
+        "scope": 186,
+        "sourceUnit": 369,
+        "src": "855:29:2",
         "symbolAliases": [],
         "unitAlias": ""
       },
       {
         "absolutePath": "interfaces/IBridgeMonitor.sol",
         "file": "./IBridgeMonitor.sol",
-        "id": 16,
+        "id": 107,
         "nodeType": "ImportDirective",
-        "scope": 95,
-        "sourceUnit": 297,
-        "src": "885:30:1",
+        "scope": 186,
+        "sourceUnit": 388,
+        "src": "885:30:2",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -761,90 +761,90 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 18,
+              "id": 109,
               "name": "IBridgeCommon",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 277,
-              "src": "1370:13:1",
+              "referencedDeclaration": 368,
+              "src": "1370:13:2",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeCommon_$277",
+                "typeIdentifier": "t_contract$_IBridgeCommon_$368",
                 "typeString": "contract IBridgeCommon"
               }
             },
-            "id": 19,
+            "id": 110,
             "nodeType": "InheritanceSpecifier",
-            "src": "1370:13:1"
+            "src": "1370:13:2"
           },
           {
             "baseName": {
-              "id": 20,
+              "id": 111,
               "name": "IBridgeMonitor",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 296,
-              "src": "1385:14:1",
+              "referencedDeclaration": 387,
+              "src": "1385:14:2",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeMonitor_$296",
+                "typeIdentifier": "t_contract$_IBridgeMonitor_$387",
                 "typeString": "contract IBridgeMonitor"
               }
             },
-            "id": 21,
+            "id": 112,
             "nodeType": "InheritanceSpecifier",
-            "src": "1385:14:1"
+            "src": "1385:14:2"
           }
         ],
         "contractDependencies": [
-          277,
-          296
+          368,
+          387
         ],
         "contractKind": "interface",
         "documentation": {
-          "id": 17,
+          "id": 108,
           "nodeType": "StructuredDocumentation",
-          "src": "918:425:1",
+          "src": "918:425:2",
           "text": " @title *Administrative* interface of Bi-directional bridge for transfer of FET tokens between Ethereum\n        and Fetch Mainnet-v2.\n @notice By design, all methods of this administrative interface can be called exclusively by administrator(s) of\n         the Bridge contract, since it allows to configure essential parameters of the the Bridge, and change\n         supply transferred across the Bridge."
         },
         "fullyImplemented": false,
-        "id": 94,
+        "id": 185,
         "linearizedBaseContracts": [
-          94,
-          296,
-          277
+          185,
+          387,
+          368
         ],
         "name": "IBridgeAdmin",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "documentation": {
-              "id": 22,
+              "id": 113,
               "nodeType": "StructuredDocumentation",
-              "src": "1407:346:1",
+              "src": "1407:346:2",
               "text": " @notice Returns amount of excess FET ERC20 tokens which were sent to address of this contract via direct ERC20\n         transfer (by calling ERC20.transfer(...)), without interacting with API of this contract, what can happen\n         only by mistake.\n @return targetAddress : address to send tokens to"
             },
             "functionSelector": "888ff935",
-            "id": 27,
+            "id": 118,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getFeesAccrued",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 23,
+              "id": 114,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1781:2:1"
+              "src": "1781:2:2"
             },
             "returnParameters": {
-              "id": 26,
+              "id": 117,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 25,
+                  "id": 116,
                   "mutability": "mutable",
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 27,
-                  "src": "1806:7:1",
+                  "scope": 118,
+                  "src": "1806:7:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -852,10 +852,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 24,
+                    "id": 115,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1806:7:1",
+                    "src": "1806:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -864,40 +864,40 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1805:9:1"
+              "src": "1805:9:2"
             },
-            "scope": 94,
-            "src": "1758:57:1",
+            "scope": 185,
+            "src": "1758:57:2",
             "stateMutability": "view",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 28,
+              "id": 119,
               "nodeType": "StructuredDocumentation",
-              "src": "1822:235:1",
+              "src": "1822:235:2",
               "text": " @notice Mints provided amount of FET tokens.\n         This is to reflect changes in minted Native FET token supply on the Fetch Native Mainnet-v2 blockchain.\n @param amount - number of FET tokens to mint."
             },
             "functionSelector": "a0712d68",
-            "id": 33,
+            "id": 124,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "mint",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 31,
+              "id": 122,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 30,
+                  "id": 121,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 33,
-                  "src": "2076:14:1",
+                  "scope": 124,
+                  "src": "2076:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -905,10 +905,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 29,
+                    "id": 120,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2076:7:1",
+                    "src": "2076:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -917,46 +917,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2075:16:1"
+              "src": "2075:16:2"
             },
             "returnParameters": {
-              "id": 32,
+              "id": 123,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2100:0:1"
+              "src": "2100:0:2"
             },
-            "scope": 94,
-            "src": "2062:39:1",
+            "scope": 185,
+            "src": "2062:39:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 34,
+              "id": 125,
               "nodeType": "StructuredDocumentation",
-              "src": "2108:235:1",
+              "src": "2108:235:2",
               "text": " @notice Burns provided amount of FET tokens.\n         This is to reflect changes in minted Native FET token supply on the Fetch Native Mainnet-v2 blockchain.\n @param amount - number of FET tokens to burn."
             },
             "functionSelector": "42966c68",
-            "id": 39,
+            "id": 130,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "burn",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 37,
+              "id": 128,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 36,
+                  "id": 127,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 39,
-                  "src": "2362:14:1",
+                  "scope": 130,
+                  "src": "2362:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -964,10 +964,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 35,
+                    "id": 126,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2362:7:1",
+                    "src": "2362:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -976,46 +976,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2361:16:1"
+              "src": "2361:16:2"
             },
             "returnParameters": {
-              "id": 38,
+              "id": 129,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2386:0:1"
+              "src": "2386:0:2"
             },
-            "scope": 94,
-            "src": "2348:39:1",
+            "scope": 185,
+            "src": "2348:39:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 40,
+              "id": 131,
               "nodeType": "StructuredDocumentation",
-              "src": "2394:337:1",
+              "src": "2394:337:2",
               "text": " @notice Sets cap (max) value of `supply` this contract can hold = the value of tokens transferred to the other\n         blockchain.\n         This cap affects(limits) all operations which *increase* contract's `supply` value = `swap(...)` and\n         `mint(...)`.\n @param value - new cap value."
             },
             "functionSelector": "47786d37",
-            "id": 45,
+            "id": 136,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setCap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 43,
+              "id": 134,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 42,
+                  "id": 133,
                   "mutability": "mutable",
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 45,
-                  "src": "2752:13:1",
+                  "scope": 136,
+                  "src": "2752:13:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1023,10 +1023,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 41,
+                    "id": 132,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2752:7:1",
+                    "src": "2752:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1035,46 +1035,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2751:15:1"
+              "src": "2751:15:2"
             },
             "returnParameters": {
-              "id": 44,
+              "id": 135,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2775:0:1"
+              "src": "2775:0:2"
             },
-            "scope": 94,
-            "src": "2736:40:1",
+            "scope": 185,
+            "src": "2736:40:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 46,
+              "id": 137,
               "nodeType": "StructuredDocumentation",
-              "src": "2783:433:1",
+              "src": "2783:433:2",
               "text": " @notice Sets value of `reverseAggregatedAllowance` state variable.\n         This affects(limits) operations which *decrease* contract's `supply` value via **RELAYER** authored\n         operations (= `reverseSwap(...)` and `refund(...)`). It does **NOT** affect **ADMINISTRATION** authored\n         supply decrease operations (= `withdraw(...)` & `burn(...)`).\n @param value - new cap value."
             },
             "functionSelector": "a85553d5",
-            "id": 51,
+            "id": 142,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setReverseAggregatedAllowance",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 49,
+              "id": 140,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 48,
+                  "id": 139,
                   "mutability": "mutable",
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 51,
-                  "src": "3260:13:1",
+                  "scope": 142,
+                  "src": "3260:13:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1082,10 +1082,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 47,
+                    "id": 138,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3260:7:1",
+                    "src": "3260:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1094,46 +1094,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3259:15:1"
+              "src": "3259:15:2"
             },
             "returnParameters": {
-              "id": 50,
+              "id": 141,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3283:0:1"
+              "src": "3283:0:2"
             },
-            "scope": 94,
-            "src": "3221:63:1",
+            "scope": 185,
+            "src": "3221:63:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 52,
+              "id": 143,
               "nodeType": "StructuredDocumentation",
-              "src": "3290:238:1",
+              "src": "3290:238:2",
               "text": " @notice Sets value of `reverseAggregatedAllowanceCap` state variable.\n         This limits APPROVER_ROLE from top - value up to which can approver rise the allowance.\n @param value - new cap value (absolute)"
             },
             "functionSelector": "0f42e312",
-            "id": 57,
+            "id": 148,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setReverseAggregatedAllowanceApproverCap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 55,
+              "id": 146,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 54,
+                  "id": 145,
                   "mutability": "mutable",
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 57,
-                  "src": "3583:13:1",
+                  "scope": 148,
+                  "src": "3583:13:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1141,10 +1141,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 53,
+                    "id": 144,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3583:7:1",
+                    "src": "3583:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1153,46 +1153,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3582:15:1"
+              "src": "3582:15:2"
             },
             "returnParameters": {
-              "id": 56,
+              "id": 147,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3606:0:1"
+              "src": "3606:0:2"
             },
-            "scope": 94,
-            "src": "3533:74:1",
+            "scope": 185,
+            "src": "3533:74:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 58,
+              "id": 149,
               "nodeType": "StructuredDocumentation",
-              "src": "3614:457:1",
+              "src": "3614:457:2",
               "text": " @notice Sets limits for swap amount\n         FUnction will revert if following consitency check fails: `swapfee_ <= swapMin_ <= swapMax_`\n @param swapMax_ : >= swap amount, applies for **OUTGOING** swap (= `swap(...)` call)\n @param swapMin_ : <= swap amount, applies for **OUTGOING** swap (= `swap(...)` call)\n @param swapFee_ : defines swap fee for **INCOMING** swap (= `reverseSwap(...)` call), and `refund(...)`"
             },
             "functionSelector": "189ae5f2",
-            "id": 67,
+            "id": 158,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setLimits",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 65,
+              "id": 156,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 60,
+                  "id": 151,
                   "mutability": "mutable",
                   "name": "swapMax_",
                   "nodeType": "VariableDeclaration",
-                  "scope": 67,
-                  "src": "4095:16:1",
+                  "scope": 158,
+                  "src": "4095:16:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1200,10 +1200,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 59,
+                    "id": 150,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4095:7:1",
+                    "src": "4095:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1213,12 +1213,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 62,
+                  "id": 153,
                   "mutability": "mutable",
                   "name": "swapMin_",
                   "nodeType": "VariableDeclaration",
-                  "scope": 67,
-                  "src": "4113:16:1",
+                  "scope": 158,
+                  "src": "4113:16:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1226,10 +1226,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 61,
+                    "id": 152,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4113:7:1",
+                    "src": "4113:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1239,12 +1239,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 64,
+                  "id": 155,
                   "mutability": "mutable",
                   "name": "swapFee_",
                   "nodeType": "VariableDeclaration",
-                  "scope": 67,
-                  "src": "4131:16:1",
+                  "scope": 158,
+                  "src": "4131:16:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1252,10 +1252,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 63,
+                    "id": 154,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4131:7:1",
+                    "src": "4131:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1264,46 +1264,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "4094:54:1"
+              "src": "4094:54:2"
             },
             "returnParameters": {
-              "id": 66,
+              "id": 157,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "4157:0:1"
+              "src": "4157:0:2"
             },
-            "scope": 94,
-            "src": "4076:82:1",
+            "scope": 185,
+            "src": "4076:82:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 68,
+              "id": 159,
               "nodeType": "StructuredDocumentation",
-              "src": "4165:302:1",
+              "src": "4165:302:2",
               "text": " @notice Withdraws amount from contract's supply, which is supposed to be done exclusively for relocating funds to\n       another Bridge system, and **NO** other purpose.\n @param targetAddress : address to send tokens to\n @param amount : amount of tokens to withdraw"
             },
             "functionSelector": "f3fef3a3",
-            "id": 75,
+            "id": 166,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "withdraw",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 73,
+              "id": 164,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 70,
+                  "id": 161,
                   "mutability": "mutable",
                   "name": "targetAddress",
                   "nodeType": "VariableDeclaration",
-                  "scope": 75,
-                  "src": "4490:21:1",
+                  "scope": 166,
+                  "src": "4490:21:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1311,10 +1311,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 69,
+                    "id": 160,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4490:7:1",
+                    "src": "4490:7:2",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1325,12 +1325,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 72,
+                  "id": 163,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 75,
-                  "src": "4513:14:1",
+                  "scope": 166,
+                  "src": "4513:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1338,10 +1338,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 71,
+                    "id": 162,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4513:7:1",
+                    "src": "4513:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1350,46 +1350,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "4489:39:1"
+              "src": "4489:39:2"
             },
             "returnParameters": {
-              "id": 74,
+              "id": 165,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "4537:0:1"
+              "src": "4537:0:2"
             },
-            "scope": 94,
-            "src": "4472:66:1",
+            "scope": 185,
+            "src": "4472:66:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 76,
+              "id": 167,
               "nodeType": "StructuredDocumentation",
-              "src": "4545:652:1",
+              "src": "4545:652:2",
               "text": " @dev Deposits funds back in to the contract supply.\n      Dedicated to increase contract's supply, usually(but not necessarily) after previous withdrawal from supply.\n      NOTE: This call needs preexisting ERC20 allowance >= `amount` for address of this Bridge contract as\n            recipient/beneficiary and Tx sender address as sender.\n            This means that address passed in as the Tx sender, must have already crated allowance by calling the\n            `ERC20.approve(from, ADDR_OF_BRIDGE_CONTRACT, amount)` *before* calling this(`deposit(...)`) call.\n @param amount : deposit amount"
             },
             "functionSelector": "b6b55f25",
-            "id": 81,
+            "id": 172,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "deposit",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 79,
+              "id": 170,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 78,
+                  "id": 169,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 81,
-                  "src": "5219:14:1",
+                  "scope": 172,
+                  "src": "5219:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1397,10 +1397,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 77,
+                    "id": 168,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "5219:7:1",
+                    "src": "5219:7:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1409,46 +1409,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "5218:16:1"
+              "src": "5218:16:2"
             },
             "returnParameters": {
-              "id": 80,
+              "id": 171,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "5243:0:1"
+              "src": "5243:0:2"
             },
-            "scope": 94,
-            "src": "5202:42:1",
+            "scope": 185,
+            "src": "5202:42:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 82,
+              "id": 173,
               "nodeType": "StructuredDocumentation",
-              "src": "5251:635:1",
+              "src": "5251:635:2",
               "text": " @notice Withdraw fees accrued so far.\n         !IMPORTANT!: Current design of this contract does *NOT* allow to distinguish between *swap fees accrued*\n                      and *excess funds* sent to the contract's address via *direct* `ERC20.transfer(...)`.\n                      Implication is that excess funds **are treated** as swap fees.\n                      The only way how to separate these two is off-chain, by replaying events from this and\n                      Fet ERC20 contracts and do the reconciliation.\n @param targetAddress : address to send tokens to."
             },
             "functionSelector": "164e68de",
-            "id": 87,
+            "id": 178,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "withdrawFees",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 85,
+              "id": 176,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 84,
+                  "id": 175,
                   "mutability": "mutable",
                   "name": "targetAddress",
                   "nodeType": "VariableDeclaration",
-                  "scope": 87,
-                  "src": "5913:21:1",
+                  "scope": 178,
+                  "src": "5913:21:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1456,10 +1456,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 83,
+                    "id": 174,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "5913:7:1",
+                    "src": "5913:7:2",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1469,46 +1469,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "5912:23:1"
+              "src": "5912:23:2"
             },
             "returnParameters": {
-              "id": 86,
+              "id": 177,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "5944:0:1"
+              "src": "5944:0:2"
             },
-            "scope": 94,
-            "src": "5891:54:1",
+            "scope": 185,
+            "src": "5891:54:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 88,
+              "id": 179,
               "nodeType": "StructuredDocumentation",
-              "src": "5952:319:1",
+              "src": "5952:319:2",
               "text": " @notice Delete the contract, transfers the remaining token and ether balance to the specified\n         payoutAddress\n @param targetAddress address to transfer the balances to. Ensure that this is able to handle ERC20 tokens\n @dev owner only + only on or after `earliestDelete` block"
             },
             "functionSelector": "2637a477",
-            "id": 93,
+            "id": 184,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "deleteContract",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 91,
+              "id": 182,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 90,
+                  "id": 181,
                   "mutability": "mutable",
                   "name": "targetAddress",
                   "nodeType": "VariableDeclaration",
-                  "scope": 93,
-                  "src": "6300:29:1",
+                  "scope": 184,
+                  "src": "6300:29:2",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1516,10 +1516,10 @@
                     "typeString": "address payable"
                   },
                   "typeName": {
-                    "id": 89,
+                    "id": 180,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "6300:15:1",
+                    "src": "6300:15:2",
                     "stateMutability": "payable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address_payable",
@@ -1529,26 +1529,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "6299:31:1"
+              "src": "6299:31:2"
             },
             "returnParameters": {
-              "id": 92,
+              "id": 183,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "6339:0:1"
+              "src": "6339:0:2"
             },
-            "scope": 94,
-            "src": "6276:64:1",
+            "scope": 185,
+            "src": "6276:64:2",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           }
         ],
-        "scope": 95,
-        "src": "1344:4998:1"
+        "scope": 186,
+        "src": "1344:4998:2"
       }
     ],
-    "src": "820:5523:1"
+    "src": "820:5523:2"
   },
   "contractName": "IBridgeAdmin",
   "dependencies": [

--- a/ethereum/build/interfaces/IBridgeCommon.json
+++ b/ethereum/build/interfaces/IBridgeCommon.json
@@ -522,15 +522,15 @@
     "absolutePath": "interfaces/IBridgeCommon.sol",
     "exportedSymbols": {
       "IBridgeCommon": [
-        277
+        368
       ]
     },
-    "id": 278,
+    "id": 369,
     "license": "Apache-2.0",
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 96,
+        "id": 187,
         "literals": [
           "solidity",
           "^",
@@ -542,7 +542,7 @@
           ".0"
         ],
         "nodeType": "PragmaDirective",
-        "src": "820:33:2"
+        "src": "820:33:3"
       },
       {
         "abstract": false,
@@ -550,37 +550,37 @@
         "contractDependencies": [],
         "contractKind": "interface",
         "documentation": {
-          "id": 97,
+          "id": 188,
           "nodeType": "StructuredDocumentation",
-          "src": "856:112:2",
+          "src": "856:112:3",
           "text": " @title Events for Bi-directional bridge transferring FET tokens between Ethereum and Fetch Mainnet-v2"
         },
         "fullyImplemented": false,
-        "id": 277,
+        "id": 368,
         "linearizedBaseContracts": [
-          277
+          368
         ],
         "name": "IBridgeCommon",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "anonymous": false,
-            "id": 109,
+            "id": 200,
             "name": "Swap",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 108,
+              "id": 199,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 99,
+                  "id": 190,
                   "indexed": true,
                   "mutability": "mutable",
                   "name": "id",
                   "nodeType": "VariableDeclaration",
-                  "scope": 109,
-                  "src": "1011:17:2",
+                  "scope": 200,
+                  "src": "1011:17:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -588,10 +588,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 98,
+                    "id": 189,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1011:6:2",
+                    "src": "1011:6:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -601,13 +601,13 @@
                 },
                 {
                   "constant": false,
-                  "id": 101,
+                  "id": 192,
                   "indexed": true,
                   "mutability": "mutable",
                   "name": "from",
                   "nodeType": "VariableDeclaration",
-                  "scope": 109,
-                  "src": "1030:20:2",
+                  "scope": 200,
+                  "src": "1030:20:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -615,10 +615,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 100,
+                    "id": 191,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1030:7:2",
+                    "src": "1030:7:3",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -629,13 +629,13 @@
                 },
                 {
                   "constant": false,
-                  "id": 103,
+                  "id": 194,
                   "indexed": true,
                   "mutability": "mutable",
                   "name": "indexedTo",
                   "nodeType": "VariableDeclaration",
-                  "scope": 109,
-                  "src": "1052:24:2",
+                  "scope": 200,
+                  "src": "1052:24:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -643,10 +643,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 102,
+                    "id": 193,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1052:6:2",
+                    "src": "1052:6:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -656,13 +656,13 @@
                 },
                 {
                   "constant": false,
-                  "id": 105,
+                  "id": 196,
                   "indexed": false,
                   "mutability": "mutable",
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 109,
-                  "src": "1078:9:2",
+                  "scope": 200,
+                  "src": "1078:9:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -670,10 +670,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 104,
+                    "id": 195,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1078:6:2",
+                    "src": "1078:6:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -683,13 +683,13 @@
                 },
                 {
                   "constant": false,
-                  "id": 107,
+                  "id": 198,
                   "indexed": false,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 109,
-                  "src": "1089:14:2",
+                  "scope": 200,
+                  "src": "1089:14:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -697,10 +697,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 106,
+                    "id": 197,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1089:7:2",
+                    "src": "1089:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -709,1112 +709,55 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1010:94:2"
+              "src": "1010:94:3"
             },
-            "src": "1000:105:2"
+            "src": "1000:105:3"
           },
           {
             "anonymous": false,
-            "id": 119,
+            "id": 210,
             "name": "SwapRefund",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 118,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 111,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "id",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 119,
-                  "src": "1128:17:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
-                  },
-                  "typeName": {
-                    "id": 110,
-                    "name": "uint64",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1128:6:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 113,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "to",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 119,
-                  "src": "1147:18:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 112,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1147:7:2",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 115,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "refundedAmount",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 119,
-                  "src": "1167:22:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 114,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1167:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 117,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "fee",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 119,
-                  "src": "1191:11:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 116,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1191:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1127:76:2"
-            },
-            "src": "1111:93:2"
-          },
-          {
-            "anonymous": false,
-            "id": 133,
-            "name": "ReverseSwap",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 132,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 121,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "rid",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 133,
-                  "src": "1227:18:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
-                  },
-                  "typeName": {
-                    "id": 120,
-                    "name": "uint64",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1227:6:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 123,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "to",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 133,
-                  "src": "1247:18:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 122,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1247:7:2",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 125,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "from",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 133,
-                  "src": "1267:19:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_string_memory_ptr",
-                    "typeString": "string"
-                  },
-                  "typeName": {
-                    "id": 124,
-                    "name": "string",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1267:6:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_string_storage_ptr",
-                      "typeString": "string"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 127,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "originTxHash",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 133,
-                  "src": "1288:20:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
-                  },
-                  "typeName": {
-                    "id": 126,
-                    "name": "bytes32",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1288:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 129,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "effectiveAmount",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 133,
-                  "src": "1310:23:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 128,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1310:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 131,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "fee",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 133,
-                  "src": "1335:11:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 130,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1335:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1226:121:2"
-            },
-            "src": "1209:139:2"
-          },
-          {
-            "anonymous": false,
-            "id": 137,
-            "name": "PausePublicApi",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 136,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 135,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "sinceBlock",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 137,
-                  "src": "1374:18:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 134,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1374:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1373:20:2"
-            },
-            "src": "1353:41:2"
-          },
-          {
-            "anonymous": false,
-            "id": 141,
-            "name": "PauseRelayerApi",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 140,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 139,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "sinceBlock",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 141,
-                  "src": "1421:18:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 138,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1421:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1420:20:2"
-            },
-            "src": "1399:42:2"
-          },
-          {
-            "anonymous": false,
-            "id": 145,
-            "name": "NewRelayEon",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 144,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 143,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "eon",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 145,
-                  "src": "1464:10:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
-                  },
-                  "typeName": {
-                    "id": 142,
-                    "name": "uint64",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1464:6:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1463:12:2"
-            },
-            "src": "1446:30:2"
-          },
-          {
-            "anonymous": false,
-            "id": 153,
-            "name": "LimitsUpdate",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 152,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 147,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "max",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 153,
-                  "src": "1501:11:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 146,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1501:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 149,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "min",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 153,
-                  "src": "1514:11:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 148,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1514:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 151,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "fee",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 153,
-                  "src": "1527:11:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 150,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1527:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1500:39:2"
-            },
-            "src": "1482:58:2"
-          },
-          {
-            "anonymous": false,
-            "id": 157,
-            "name": "CapUpdate",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 156,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 155,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "value",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 157,
-                  "src": "1561:13:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 154,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1561:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1560:15:2"
-            },
-            "src": "1545:31:2"
-          },
-          {
-            "anonymous": false,
-            "id": 161,
-            "name": "ReverseAggregatedAllowanceUpdate",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 160,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 159,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "value",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 161,
-                  "src": "1620:13:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 158,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1620:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1619:15:2"
-            },
-            "src": "1581:54:2"
-          },
-          {
-            "anonymous": false,
-            "id": 165,
-            "name": "ReverseAggregatedAllowanceApproverCapUpdate",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 164,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 163,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "value",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 165,
-                  "src": "1690:13:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 162,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1690:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1689:15:2"
-            },
-            "src": "1640:65:2"
-          },
-          {
-            "anonymous": false,
-            "id": 171,
-            "name": "Withdraw",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 170,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 167,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "targetAddress",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 171,
-                  "src": "1725:29:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 166,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1725:7:2",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 169,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "amount",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 171,
-                  "src": "1756:14:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 168,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1756:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1724:47:2"
-            },
-            "src": "1710:62:2"
-          },
-          {
-            "anonymous": false,
-            "id": 177,
-            "name": "Deposit",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 176,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 173,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "fromAddress",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 177,
-                  "src": "1791:27:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 172,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1791:7:2",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 175,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "amount",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 177,
-                  "src": "1820:14:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 174,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1820:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1790:45:2"
-            },
-            "src": "1777:59:2"
-          },
-          {
-            "anonymous": false,
-            "id": 183,
-            "name": "FeesWithdrawal",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 182,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 179,
-                  "indexed": true,
-                  "mutability": "mutable",
-                  "name": "targetAddress",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 183,
-                  "src": "1862:29:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 178,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1862:7:2",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 181,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "amount",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 183,
-                  "src": "1893:14:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 180,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1893:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1861:47:2"
-            },
-            "src": "1841:68:2"
-          },
-          {
-            "anonymous": false,
-            "id": 189,
-            "name": "DeleteContract",
-            "nodeType": "EventDefinition",
-            "parameters": {
-              "id": 188,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 185,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "targetAddress",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 189,
-                  "src": "1935:21:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 184,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1935:7:2",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 187,
-                  "indexed": false,
-                  "mutability": "mutable",
-                  "name": "amount",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 189,
-                  "src": "1958:14:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 186,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1958:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1934:39:2"
-            },
-            "src": "1914:60:2"
-          },
-          {
-            "functionSelector": "61814525",
-            "id": 194,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getApproverRole",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 190,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "2658:2:2"
-            },
-            "returnParameters": {
-              "id": 193,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 192,
-                  "mutability": "mutable",
-                  "name": "",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 194,
-                  "src": "2683:7:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
-                  },
-                  "typeName": {
-                    "id": 191,
-                    "name": "bytes32",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "2683:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "2682:9:2"
-            },
-            "scope": 277,
-            "src": "2634:58:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
-          },
-          {
-            "functionSelector": "9c7dc431",
-            "id": 199,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getMonitorRole",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 195,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "2720:2:2"
-            },
-            "returnParameters": {
-              "id": 198,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 197,
-                  "mutability": "mutable",
-                  "name": "",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 199,
-                  "src": "2745:7:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
-                  },
-                  "typeName": {
-                    "id": 196,
-                    "name": "bytes32",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "2745:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "2744:9:2"
-            },
-            "scope": 277,
-            "src": "2697:57:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
-          },
-          {
-            "functionSelector": "7af9028a",
-            "id": 204,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getRelayerRole",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 200,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "2782:2:2"
-            },
-            "returnParameters": {
-              "id": 203,
+              "id": 209,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
                   "id": 202,
+                  "indexed": true,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "id",
                   "nodeType": "VariableDeclaration",
-                  "scope": 204,
-                  "src": "2807:7:2",
+                  "scope": 210,
+                  "src": "1128:17:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
                   },
                   "typeName": {
                     "id": 201,
-                    "name": "bytes32",
+                    "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2807:7:2",
+                    "src": "1128:6:3",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
                     }
                   },
                   "visibility": "internal"
-                }
-              ],
-              "src": "2806:9:2"
-            },
-            "scope": 277,
-            "src": "2759:57:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
-          },
-          {
-            "functionSelector": "21df0da7",
-            "id": 209,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getToken",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 205,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "2839:2:2"
-            },
-            "returnParameters": {
-              "id": 208,
-              "nodeType": "ParameterList",
-              "parameters": [
+                },
                 {
                   "constant": false,
-                  "id": 207,
+                  "id": 204,
+                  "indexed": true,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 209,
-                  "src": "2864:7:2",
+                  "scope": 210,
+                  "src": "1147:18:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1822,10 +765,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 206,
+                    "id": 203,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2864:7:2",
+                    "src": "1147:7:3",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1833,42 +776,16 @@
                     }
                   },
                   "visibility": "internal"
-                }
-              ],
-              "src": "2863:9:2"
-            },
-            "scope": 277,
-            "src": "2822:51:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
-          },
-          {
-            "functionSelector": "aa896137",
-            "id": 214,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getEarliestDelete",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 210,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "2904:2:2"
-            },
-            "returnParameters": {
-              "id": 213,
-              "nodeType": "ParameterList",
-              "parameters": [
+                },
                 {
                   "constant": false,
-                  "id": 212,
+                  "id": 206,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "refundedAmount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 214,
-                  "src": "2929:7:2",
+                  "scope": 210,
+                  "src": "1167:22:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1876,10 +793,37 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 211,
+                    "id": 205,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2929:7:2",
+                    "src": "1167:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 208,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "fee",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 210,
+                  "src": "1191:11:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 207,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1191:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1888,279 +832,328 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2928:9:2"
+              "src": "1127:76:3"
             },
-            "scope": 277,
-            "src": "2878:60:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
+            "src": "1111:93:3"
           },
           {
-            "functionSelector": "6c9c2faf",
-            "id": 219,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getSupply",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 215,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "2961:2:2"
-            },
-            "returnParameters": {
-              "id": 218,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 217,
-                  "mutability": "mutable",
-                  "name": "",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 219,
-                  "src": "2986:7:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 216,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "2986:7:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "2985:9:2"
-            },
-            "scope": 277,
-            "src": "2943:52:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
-          },
-          {
-            "functionSelector": "f4b01b12",
+            "anonymous": false,
             "id": 224,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getNextSwapId",
-            "nodeType": "FunctionDefinition",
+            "name": "ReverseSwap",
+            "nodeType": "EventDefinition",
             "parameters": {
-              "id": 220,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "3022:2:2"
-            },
-            "returnParameters": {
               "id": 223,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 222,
+                  "id": 212,
+                  "indexed": true,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "rid",
                   "nodeType": "VariableDeclaration",
                   "scope": 224,
-                  "src": "3047:6:2",
+                  "src": "1227:18:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint64",
                     "typeString": "uint64"
+                  },
+                  "typeName": {
+                    "id": 211,
+                    "name": "uint64",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1227:6:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 214,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "to",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 224,
+                  "src": "1247:18:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 213,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1247:7:3",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 216,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "from",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 224,
+                  "src": "1267:19:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_string_memory_ptr",
+                    "typeString": "string"
+                  },
+                  "typeName": {
+                    "id": 215,
+                    "name": "string",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1267:6:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_string_storage_ptr",
+                      "typeString": "string"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 218,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "originTxHash",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 224,
+                  "src": "1288:20:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 217,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1288:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 220,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "effectiveAmount",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 224,
+                  "src": "1310:23:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 219,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1310:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 222,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "fee",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 224,
+                  "src": "1335:11:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
                   },
                   "typeName": {
                     "id": 221,
-                    "name": "uint64",
+                    "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3047:6:2",
+                    "src": "1335:7:3",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "3046:8:2"
+              "src": "1226:121:3"
             },
-            "scope": 277,
-            "src": "3000:55:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
+            "src": "1209:139:3"
           },
           {
-            "functionSelector": "d162d6ee",
-            "id": 229,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getRelayEon",
-            "nodeType": "FunctionDefinition",
+            "anonymous": false,
+            "id": 228,
+            "name": "PausePublicApi",
+            "nodeType": "EventDefinition",
             "parameters": {
-              "id": 225,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "3080:2:2"
-            },
-            "returnParameters": {
-              "id": 228,
+              "id": 227,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 227,
+                  "id": 226,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "sinceBlock",
                   "nodeType": "VariableDeclaration",
-                  "scope": 229,
-                  "src": "3105:6:2",
+                  "scope": 228,
+                  "src": "1374:18:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 226,
-                    "name": "uint64",
+                    "id": 225,
+                    "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3105:6:2",
+                    "src": "1374:7:3",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "3104:8:2"
+              "src": "1373:20:3"
             },
-            "scope": 277,
-            "src": "3060:53:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
+            "src": "1353:41:3"
           },
           {
-            "functionSelector": "88f5b9a5",
+            "anonymous": false,
+            "id": 232,
+            "name": "PauseRelayerApi",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 231,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 230,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "sinceBlock",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 232,
+                  "src": "1421:18:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 229,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1421:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1420:20:3"
+            },
+            "src": "1399:42:3"
+          },
+          {
+            "anonymous": false,
             "id": 236,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getRefund",
-            "nodeType": "FunctionDefinition",
+            "name": "NewRelayEon",
+            "nodeType": "EventDefinition",
             "parameters": {
-              "id": 232,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 231,
-                  "mutability": "mutable",
-                  "name": "swap_id",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 236,
-                  "src": "3137:14:2",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
-                  },
-                  "typeName": {
-                    "id": 230,
-                    "name": "uint64",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "3137:6:2",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "3136:16:2"
-            },
-            "returnParameters": {
               "id": 235,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
                   "id": 234,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "eon",
                   "nodeType": "VariableDeclaration",
                   "scope": 236,
-                  "src": "3175:7:2",
+                  "src": "1464:10:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
                   },
                   "typeName": {
                     "id": 233,
-                    "name": "uint256",
+                    "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3175:7:2",
+                    "src": "1464:6:3",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "3174:9:2"
+              "src": "1463:12:3"
             },
-            "scope": 277,
-            "src": "3118:66:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
+            "src": "1446:30:3"
           },
           {
-            "functionSelector": "b525aca9",
-            "id": 241,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getSwapMax",
-            "nodeType": "FunctionDefinition",
+            "anonymous": false,
+            "id": 244,
+            "name": "LimitsUpdate",
+            "nodeType": "EventDefinition",
             "parameters": {
-              "id": 237,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "3264:2:2"
-            },
-            "returnParameters": {
-              "id": 240,
+              "id": 243,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 239,
+                  "id": 238,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "max",
                   "nodeType": "VariableDeclaration",
-                  "scope": 241,
-                  "src": "3289:7:2",
+                  "scope": 244,
+                  "src": "1501:11:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2168,52 +1161,26 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 238,
+                    "id": 237,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3289:7:2",
+                    "src": "1501:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     }
                   },
                   "visibility": "internal"
-                }
-              ],
-              "src": "3288:9:2"
-            },
-            "scope": 277,
-            "src": "3245:53:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
-          },
-          {
-            "functionSelector": "466a78c0",
-            "id": 246,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getSwapMin",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 242,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "3322:2:2"
-            },
-            "returnParameters": {
-              "id": 245,
-              "nodeType": "ParameterList",
-              "parameters": [
+                },
                 {
                   "constant": false,
-                  "id": 244,
+                  "id": 240,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "min",
                   "nodeType": "VariableDeclaration",
-                  "scope": 246,
-                  "src": "3347:7:2",
+                  "scope": 244,
+                  "src": "1514:11:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2221,10 +1188,37 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 243,
+                    "id": 239,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3347:7:2",
+                    "src": "1514:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 242,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "fee",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 244,
+                  "src": "1527:11:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 241,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1527:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2233,40 +1227,28 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3346:9:2"
+              "src": "1500:39:3"
             },
-            "scope": 277,
-            "src": "3303:53:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
+            "src": "1482:58:3"
           },
           {
-            "functionSelector": "554d578d",
-            "id": 251,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getCap",
-            "nodeType": "FunctionDefinition",
+            "anonymous": false,
+            "id": 248,
+            "name": "CapUpdate",
+            "nodeType": "EventDefinition",
             "parameters": {
               "id": 247,
               "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "3376:2:2"
-            },
-            "returnParameters": {
-              "id": 250,
-              "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 249,
+                  "id": 246,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 251,
-                  "src": "3401:7:2",
+                  "scope": 248,
+                  "src": "1561:13:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2274,10 +1256,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 248,
+                    "id": 245,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3401:7:2",
+                    "src": "1561:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2286,40 +1268,69 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3400:9:2"
+              "src": "1560:15:3"
             },
-            "scope": 277,
-            "src": "3361:49:2",
-            "stateMutability": "view",
-            "virtual": false,
-            "visibility": "external"
+            "src": "1545:31:3"
           },
           {
-            "functionSelector": "d4cadf68",
-            "id": 256,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "getSwapFee",
-            "nodeType": "FunctionDefinition",
+            "anonymous": false,
+            "id": 252,
+            "name": "ReverseAggregatedAllowanceUpdate",
+            "nodeType": "EventDefinition",
             "parameters": {
-              "id": 252,
+              "id": 251,
               "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "3434:2:2"
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 250,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "value",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 252,
+                  "src": "1620:13:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 249,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1620:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1619:15:3"
             },
-            "returnParameters": {
+            "src": "1581:54:3"
+          },
+          {
+            "anonymous": false,
+            "id": 256,
+            "name": "ReverseAggregatedAllowanceApproverCapUpdate",
+            "nodeType": "EventDefinition",
+            "parameters": {
               "id": 255,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
                   "id": 254,
+                  "indexed": false,
                   "mutability": "mutable",
-                  "name": "",
+                  "name": "value",
                   "nodeType": "VariableDeclaration",
                   "scope": 256,
-                  "src": "3459:7:2",
+                  "src": "1690:13:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2330,7 +1341,7 @@
                     "id": 253,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3459:7:2",
+                    "src": "1690:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2339,40 +1350,1029 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3458:9:2"
+              "src": "1689:15:3"
             },
-            "scope": 277,
-            "src": "3415:53:2",
+            "src": "1640:65:3"
+          },
+          {
+            "anonymous": false,
+            "id": 262,
+            "name": "Withdraw",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 261,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 258,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "targetAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 262,
+                  "src": "1725:29:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 257,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1725:7:3",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 260,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "amount",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 262,
+                  "src": "1756:14:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 259,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1756:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1724:47:3"
+            },
+            "src": "1710:62:3"
+          },
+          {
+            "anonymous": false,
+            "id": 268,
+            "name": "Deposit",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 267,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 264,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "fromAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 268,
+                  "src": "1791:27:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 263,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1791:7:3",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 266,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "amount",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 268,
+                  "src": "1820:14:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 265,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1820:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1790:45:3"
+            },
+            "src": "1777:59:3"
+          },
+          {
+            "anonymous": false,
+            "id": 274,
+            "name": "FeesWithdrawal",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 273,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 270,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "targetAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 274,
+                  "src": "1862:29:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 269,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1862:7:3",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 272,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "amount",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 274,
+                  "src": "1893:14:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 271,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1893:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1861:47:3"
+            },
+            "src": "1841:68:3"
+          },
+          {
+            "anonymous": false,
+            "id": 280,
+            "name": "DeleteContract",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 279,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 276,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "targetAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 280,
+                  "src": "1935:21:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 275,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1935:7:3",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 278,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "amount",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 280,
+                  "src": "1958:14:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 277,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1958:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1934:39:3"
+            },
+            "src": "1914:60:3"
+          },
+          {
+            "functionSelector": "61814525",
+            "id": 285,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getApproverRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 281,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2658:2:3"
+            },
+            "returnParameters": {
+              "id": 284,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 283,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 285,
+                  "src": "2683:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 282,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2683:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2682:9:3"
+            },
+            "scope": 368,
+            "src": "2634:58:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "9c7dc431",
+            "id": 290,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getMonitorRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 286,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2720:2:3"
+            },
+            "returnParameters": {
+              "id": 289,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 288,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 290,
+                  "src": "2745:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 287,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2745:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2744:9:3"
+            },
+            "scope": 368,
+            "src": "2697:57:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "7af9028a",
+            "id": 295,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getRelayerRole",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 291,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2782:2:3"
+            },
+            "returnParameters": {
+              "id": 294,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 293,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 295,
+                  "src": "2807:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes32",
+                    "typeString": "bytes32"
+                  },
+                  "typeName": {
+                    "id": 292,
+                    "name": "bytes32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2807:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2806:9:3"
+            },
+            "scope": 368,
+            "src": "2759:57:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "21df0da7",
+            "id": 300,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getToken",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 296,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2839:2:3"
+            },
+            "returnParameters": {
+              "id": 299,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 298,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 300,
+                  "src": "2864:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 297,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2864:7:3",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2863:9:3"
+            },
+            "scope": 368,
+            "src": "2822:51:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "aa896137",
+            "id": 305,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getEarliestDelete",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 301,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2904:2:3"
+            },
+            "returnParameters": {
+              "id": 304,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 303,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 305,
+                  "src": "2929:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 302,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2929:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2928:9:3"
+            },
+            "scope": 368,
+            "src": "2878:60:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "6c9c2faf",
+            "id": 310,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getSupply",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 306,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2961:2:3"
+            },
+            "returnParameters": {
+              "id": 309,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 308,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 310,
+                  "src": "2986:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 307,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2986:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2985:9:3"
+            },
+            "scope": 368,
+            "src": "2943:52:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "f4b01b12",
+            "id": 315,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getNextSwapId",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 311,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3022:2:3"
+            },
+            "returnParameters": {
+              "id": 314,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 313,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 315,
+                  "src": "3047:6:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
+                  },
+                  "typeName": {
+                    "id": 312,
+                    "name": "uint64",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3047:6:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3046:8:3"
+            },
+            "scope": 368,
+            "src": "3000:55:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "d162d6ee",
+            "id": 320,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getRelayEon",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 316,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3080:2:3"
+            },
+            "returnParameters": {
+              "id": 319,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 318,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 320,
+                  "src": "3105:6:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
+                  },
+                  "typeName": {
+                    "id": 317,
+                    "name": "uint64",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3105:6:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3104:8:3"
+            },
+            "scope": 368,
+            "src": "3060:53:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "88f5b9a5",
+            "id": 327,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getRefund",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 323,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 322,
+                  "mutability": "mutable",
+                  "name": "swap_id",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 327,
+                  "src": "3137:14:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
+                  },
+                  "typeName": {
+                    "id": 321,
+                    "name": "uint64",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3137:6:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3136:16:3"
+            },
+            "returnParameters": {
+              "id": 326,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 325,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 327,
+                  "src": "3175:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 324,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3175:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3174:9:3"
+            },
+            "scope": 368,
+            "src": "3118:66:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "b525aca9",
+            "id": 332,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getSwapMax",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 328,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3264:2:3"
+            },
+            "returnParameters": {
+              "id": 331,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 330,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 332,
+                  "src": "3289:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 329,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3289:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3288:9:3"
+            },
+            "scope": 368,
+            "src": "3245:53:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "466a78c0",
+            "id": 337,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getSwapMin",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 333,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3322:2:3"
+            },
+            "returnParameters": {
+              "id": 336,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 335,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 337,
+                  "src": "3347:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 334,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3347:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3346:9:3"
+            },
+            "scope": 368,
+            "src": "3303:53:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "554d578d",
+            "id": 342,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getCap",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 338,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3376:2:3"
+            },
+            "returnParameters": {
+              "id": 341,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 340,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 342,
+                  "src": "3401:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 339,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3401:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3400:9:3"
+            },
+            "scope": 368,
+            "src": "3361:49:3",
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "functionSelector": "d4cadf68",
+            "id": 347,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "getSwapFee",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 343,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3434:2:3"
+            },
+            "returnParameters": {
+              "id": 346,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 345,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 347,
+                  "src": "3459:7:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 344,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3459:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3458:9:3"
+            },
+            "scope": 368,
+            "src": "3415:53:3",
             "stateMutability": "view",
             "virtual": false,
             "visibility": "external"
           },
           {
             "functionSelector": "4fe9dc48",
-            "id": 261,
+            "id": 352,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getPausedSinceBlockPublicApi",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 257,
+              "id": 348,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3510:2:2"
+              "src": "3510:2:3"
             },
             "returnParameters": {
-              "id": 260,
+              "id": 351,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 259,
+                  "id": 350,
                   "mutability": "mutable",
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 261,
-                  "src": "3535:7:2",
+                  "scope": 352,
+                  "src": "3535:7:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2380,10 +2380,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 258,
+                    "id": 349,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3535:7:2",
+                    "src": "3535:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2392,40 +2392,40 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3534:9:2"
+              "src": "3534:9:3"
             },
-            "scope": 277,
-            "src": "3473:71:2",
+            "scope": 368,
+            "src": "3473:71:3",
             "stateMutability": "view",
             "virtual": false,
             "visibility": "external"
           },
           {
             "functionSelector": "0a80943e",
-            "id": 266,
+            "id": 357,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getPausedSinceBlockRelayerApi",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 262,
+              "id": 353,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3587:2:2"
+              "src": "3587:2:3"
             },
             "returnParameters": {
-              "id": 265,
+              "id": 356,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 264,
+                  "id": 355,
                   "mutability": "mutable",
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 266,
-                  "src": "3612:7:2",
+                  "scope": 357,
+                  "src": "3612:7:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2433,10 +2433,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 263,
+                    "id": 354,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3612:7:2",
+                    "src": "3612:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2445,40 +2445,40 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3611:9:2"
+              "src": "3611:9:3"
             },
-            "scope": 277,
-            "src": "3549:72:2",
+            "scope": 368,
+            "src": "3549:72:3",
             "stateMutability": "view",
             "virtual": false,
             "visibility": "external"
           },
           {
             "functionSelector": "680eb185",
-            "id": 271,
+            "id": 362,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getReverseAggregatedAllowance",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 267,
+              "id": 358,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3664:2:2"
+              "src": "3664:2:3"
             },
             "returnParameters": {
-              "id": 270,
+              "id": 361,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 269,
+                  "id": 360,
                   "mutability": "mutable",
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 271,
-                  "src": "3689:7:2",
+                  "scope": 362,
+                  "src": "3689:7:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2486,10 +2486,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 268,
+                    "id": 359,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3689:7:2",
+                    "src": "3689:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2498,40 +2498,40 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3688:9:2"
+              "src": "3688:9:3"
             },
-            "scope": 277,
-            "src": "3626:72:2",
+            "scope": 368,
+            "src": "3626:72:3",
             "stateMutability": "view",
             "virtual": false,
             "visibility": "external"
           },
           {
             "functionSelector": "b8f0afbd",
-            "id": 276,
+            "id": 367,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getReverseAggregatedAllowanceApproverCap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 272,
+              "id": 363,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3752:2:2"
+              "src": "3752:2:3"
             },
             "returnParameters": {
-              "id": 275,
+              "id": 366,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 274,
+                  "id": 365,
                   "mutability": "mutable",
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 276,
-                  "src": "3777:7:2",
+                  "scope": 367,
+                  "src": "3777:7:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2539,10 +2539,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 273,
+                    "id": 364,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3777:7:2",
+                    "src": "3777:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2551,20 +2551,20 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3776:9:2"
+              "src": "3776:9:3"
             },
-            "scope": 277,
-            "src": "3703:83:2",
+            "scope": 368,
+            "src": "3703:83:3",
             "stateMutability": "view",
             "virtual": false,
             "visibility": "external"
           }
         ],
-        "scope": 278,
-        "src": "969:2820:2"
+        "scope": 369,
+        "src": "969:2820:3"
       }
     ],
-    "src": "820:2970:2"
+    "src": "820:2970:3"
   },
   "contractName": "IBridgeCommon",
   "dependencies": [],

--- a/ethereum/build/interfaces/IBridgeMonitor.json
+++ b/ethereum/build/interfaces/IBridgeMonitor.json
@@ -548,18 +548,18 @@
     "absolutePath": "interfaces/IBridgeMonitor.sol",
     "exportedSymbols": {
       "IBridgeCommon": [
-        277
+        368
       ],
       "IBridgeMonitor": [
-        296
+        387
       ]
     },
-    "id": 297,
+    "id": 388,
     "license": "Apache-2.0",
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 279,
+        "id": 370,
         "literals": [
           "solidity",
           "^",
@@ -571,16 +571,16 @@
           ".0"
         ],
         "nodeType": "PragmaDirective",
-        "src": "821:33:3"
+        "src": "821:33:4"
       },
       {
         "absolutePath": "interfaces/IBridgeCommon.sol",
         "file": "./IBridgeCommon.sol",
-        "id": 280,
+        "id": 371,
         "nodeType": "ImportDirective",
-        "scope": 297,
-        "sourceUnit": 278,
-        "src": "856:29:3",
+        "scope": 388,
+        "sourceUnit": 369,
+        "src": "856:29:4",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -589,66 +589,66 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 282,
+              "id": 373,
               "name": "IBridgeCommon",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 277,
-              "src": "1200:13:3",
+              "referencedDeclaration": 368,
+              "src": "1200:13:4",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeCommon_$277",
+                "typeIdentifier": "t_contract$_IBridgeCommon_$368",
                 "typeString": "contract IBridgeCommon"
               }
             },
-            "id": 283,
+            "id": 374,
             "nodeType": "InheritanceSpecifier",
-            "src": "1200:13:3"
+            "src": "1200:13:4"
           }
         ],
         "contractDependencies": [
-          277
+          368
         ],
         "contractKind": "interface",
         "documentation": {
-          "id": 281,
+          "id": 372,
           "nodeType": "StructuredDocumentation",
-          "src": "888:283:3",
+          "src": "888:283:4",
           "text": " @title *Monitor* interface of Bi-directional bridge for transfer of FET tokens between Ethereum\n        and Fetch Mainnet-v2.\n @notice By design, all methods of this monitor-level interface can be called monitor and admin roles of\n         the Bridge contract."
         },
         "fullyImplemented": false,
-        "id": 296,
+        "id": 387,
         "linearizedBaseContracts": [
-          296,
-          277
+          387,
+          368
         ],
         "name": "IBridgeMonitor",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "documentation": {
-              "id": 284,
+              "id": 375,
               "nodeType": "StructuredDocumentation",
-              "src": "1220:353:3",
+              "src": "1220:353:4",
               "text": " @notice Pauses Public API since the specified block number\n @param blockNumber block number since which non-admin interaction will be paused (for all\n        block.number >= blockNumber).\n @dev Delegate only\n      If `blocknumber < block.number`, then contract will be paused immediately = from `block.number`."
             },
             "functionSelector": "432944c0",
-            "id": 289,
+            "id": 380,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "pausePublicApiSince",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 287,
+              "id": 378,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 286,
+                  "id": 377,
                   "mutability": "mutable",
                   "name": "blockNumber",
                   "nodeType": "VariableDeclaration",
-                  "scope": 289,
-                  "src": "1607:19:3",
+                  "scope": 380,
+                  "src": "1607:19:4",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -656,10 +656,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 285,
+                    "id": 376,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1607:7:3",
+                    "src": "1607:7:4",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -668,46 +668,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1606:21:3"
+              "src": "1606:21:4"
             },
             "returnParameters": {
-              "id": 288,
+              "id": 379,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1636:0:3"
+              "src": "1636:0:4"
             },
-            "scope": 296,
-            "src": "1578:59:3",
+            "scope": 387,
+            "src": "1578:59:4",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 290,
+              "id": 381,
               "nodeType": "StructuredDocumentation",
-              "src": "1643:354:3",
+              "src": "1643:354:4",
               "text": " @notice Pauses Relayer API since the specified block number\n @param blockNumber block number since which non-admin interaction will be paused (for all\n        block.number >= blockNumber).\n @dev Delegate only\n      If `blocknumber < block.number`, then contract will be paused immediately = from `block.number`."
             },
             "functionSelector": "9f2c88bf",
-            "id": 295,
+            "id": 386,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "pauseRelayerApiSince",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 293,
+              "id": 384,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 292,
+                  "id": 383,
                   "mutability": "mutable",
                   "name": "blockNumber",
                   "nodeType": "VariableDeclaration",
-                  "scope": 295,
-                  "src": "2032:19:3",
+                  "scope": 386,
+                  "src": "2032:19:4",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -715,10 +715,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 291,
+                    "id": 382,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2032:7:3",
+                    "src": "2032:7:4",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -727,26 +727,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2031:21:3"
+              "src": "2031:21:4"
             },
             "returnParameters": {
-              "id": 294,
+              "id": 385,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2061:0:3"
+              "src": "2061:0:4"
             },
-            "scope": 296,
-            "src": "2002:60:3",
+            "scope": 387,
+            "src": "2002:60:4",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           }
         ],
-        "scope": 297,
-        "src": "1172:892:3"
+        "scope": 388,
+        "src": "1172:892:4"
       }
     ],
-    "src": "821:1244:3"
+    "src": "821:1244:4"
   },
   "contractName": "IBridgeMonitor",
   "dependencies": [

--- a/ethereum/build/interfaces/IBridgePublic.json
+++ b/ethereum/build/interfaces/IBridgePublic.json
@@ -540,18 +540,18 @@
     "absolutePath": "interfaces/IBridgePublic.sol",
     "exportedSymbols": {
       "IBridgeCommon": [
-        277
+        368
       ],
       "IBridgePublic": [
-        311
+        402
       ]
     },
-    "id": 312,
+    "id": 403,
     "license": "Apache-2.0",
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 298,
+        "id": 389,
         "literals": [
           "solidity",
           "^",
@@ -563,16 +563,16 @@
           ".0"
         ],
         "nodeType": "PragmaDirective",
-        "src": "820:33:4"
+        "src": "820:33:5"
       },
       {
         "absolutePath": "interfaces/IBridgeCommon.sol",
         "file": "./IBridgeCommon.sol",
-        "id": 299,
+        "id": 390,
         "nodeType": "ImportDirective",
-        "scope": 312,
-        "sourceUnit": 278,
-        "src": "855:29:4",
+        "scope": 403,
+        "sourceUnit": 369,
+        "src": "855:29:5",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -581,66 +581,66 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 301,
+              "id": 392,
               "name": "IBridgeCommon",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 277,
-              "src": "1125:13:4",
+              "referencedDeclaration": 368,
+              "src": "1125:13:5",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeCommon_$277",
+                "typeIdentifier": "t_contract$_IBridgeCommon_$368",
                 "typeString": "contract IBridgeCommon"
               }
             },
-            "id": 302,
+            "id": 393,
             "nodeType": "InheritanceSpecifier",
-            "src": "1125:13:4"
+            "src": "1125:13:5"
           }
         ],
         "contractDependencies": [
-          277
+          368
         ],
         "contractKind": "interface",
         "documentation": {
-          "id": 300,
+          "id": 391,
           "nodeType": "StructuredDocumentation",
-          "src": "887:210:4",
+          "src": "887:210:5",
           "text": " @title Public interface of the Bridge for transferring FET tokens between Ethereum and Fetch Mainnet-v2\n @notice Methods of this public interface is allow users to interact with Bridge contract."
         },
         "fullyImplemented": false,
-        "id": 311,
+        "id": 402,
         "linearizedBaseContracts": [
-          311,
-          277
+          402,
+          368
         ],
         "name": "IBridgePublic",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "documentation": {
-              "id": 303,
+              "id": 394,
               "nodeType": "StructuredDocumentation",
-              "src": "1146:2061:4",
+              "src": "1146:2061:5",
               "text": " @notice Initiates swap, which will be relayed to the other blockchain.\n         Swap might fail, if `destinationAddress` value is invalid (see bellow), in which case the swap will be\n         refunded back to user. Swap fee will be *WITHDRAWN* from `amount` in that case - please see details\n         in desc. for `refund(...)` call.\n @dev Swap call will create unique identifier (swap id), which is, by design, sequentially growing by 1 per each\n      new swap created, and so uniquely identifies each swap. This identifier is referred to as \"reverse swap id\"\n      on the other blockchain.\n      Callable by anyone.\n @param destinationAddress - address on **OTHER** blockchain where the swap effective amount will be transferred\n                             in to.\n                             User is **RESPONSIBLE** for providing the **CORRECT** and valid value.\n                             The **CORRECT** means, in this context, that address is valid *AND* user really\n                             intended this particular address value as destination = that address is NOT lets say\n                             copy-paste mistake made by user. Reason being that when user provided valid address\n                             value, but made mistake = address is of someone else (e.g. copy-paste mistake), then\n                             there is **NOTHING** what can be done to recover funds back to user (= refund) once\n                             the swap will be relayed to the other blockchain!\n                             The **VALID** means that provided value successfully passes consistency checks of\n                             valid address of **OTHER** blockchain. In the case when user provides invalid\n                             address value, relayer will execute refund - please see desc. for `refund()` call\n                             for more details."
             },
             "functionSelector": "deb4a6d2",
-            "id": 310,
+            "id": 401,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "swap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 308,
+              "id": 399,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 305,
+                  "id": 396,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 310,
-                  "src": "3226:14:4",
+                  "scope": 401,
+                  "src": "3226:14:5",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -648,10 +648,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 304,
+                    "id": 395,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3226:7:4",
+                    "src": "3226:7:5",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -661,12 +661,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 307,
+                  "id": 398,
                   "mutability": "mutable",
                   "name": "destinationAddress",
                   "nodeType": "VariableDeclaration",
-                  "scope": 310,
-                  "src": "3242:34:4",
+                  "scope": 401,
+                  "src": "3242:34:5",
                   "stateVariable": false,
                   "storageLocation": "calldata",
                   "typeDescriptions": {
@@ -674,10 +674,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 306,
+                    "id": 397,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3242:6:4",
+                    "src": "3242:6:5",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -686,26 +686,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3225:52:4"
+              "src": "3225:52:5"
             },
             "returnParameters": {
-              "id": 309,
+              "id": 400,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3286:0:4"
+              "src": "3286:0:5"
             },
-            "scope": 311,
-            "src": "3212:75:4",
+            "scope": 402,
+            "src": "3212:75:5",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           }
         ],
-        "scope": 312,
-        "src": "1098:2191:4"
+        "scope": 403,
+        "src": "1098:2191:5"
       }
     ],
-    "src": "820:2470:4"
+    "src": "820:2470:5"
   },
   "contractName": "IBridgePublic",
   "dependencies": [

--- a/ethereum/build/interfaces/IBridgeRelayer.json
+++ b/ethereum/build/interfaces/IBridgeRelayer.json
@@ -623,18 +623,18 @@
     "absolutePath": "interfaces/IBridgeRelayer.sol",
     "exportedSymbols": {
       "IBridgeCommon": [
-        277
+        368
       ],
       "IBridgeRelayer": [
-        362
+        453
       ]
     },
-    "id": 363,
+    "id": 454,
     "license": "Apache-2.0",
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 313,
+        "id": 404,
         "literals": [
           "solidity",
           "^",
@@ -646,16 +646,16 @@
           ".0"
         ],
         "nodeType": "PragmaDirective",
-        "src": "820:33:5"
+        "src": "820:33:6"
       },
       {
         "absolutePath": "interfaces/IBridgeCommon.sol",
         "file": "./IBridgeCommon.sol",
-        "id": 314,
+        "id": 405,
         "nodeType": "ImportDirective",
-        "scope": 363,
-        "sourceUnit": 278,
-        "src": "855:29:5",
+        "scope": 454,
+        "sourceUnit": 369,
+        "src": "855:29:6",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -664,98 +664,98 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 316,
+              "id": 407,
               "name": "IBridgeCommon",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 277,
-              "src": "2103:13:5",
+              "referencedDeclaration": 368,
+              "src": "2103:13:6",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IBridgeCommon_$277",
+                "typeIdentifier": "t_contract$_IBridgeCommon_$368",
                 "typeString": "contract IBridgeCommon"
               }
             },
-            "id": 317,
+            "id": 408,
             "nodeType": "InheritanceSpecifier",
-            "src": "2103:13:5"
+            "src": "2103:13:6"
           }
         ],
         "contractDependencies": [
-          277
+          368
         ],
         "contractKind": "interface",
         "documentation": {
-          "id": 315,
+          "id": 406,
           "nodeType": "StructuredDocumentation",
-          "src": "887:1187:5",
+          "src": "887:1187:6",
           "text": " @title *Relayer* interface of Bi-directional bridge for transfer of FET tokens between Ethereum\n        and Fetch Mainnet-v2.\n @notice By design, all methods of this relayer-level interface can be called exclusively by relayer(s) of\n         the Bridge contract.\n         It is offers set of methods to perform relaying functionality of the Bridge = transferring swaps\n         across chains.\n @notice This bridge allows to transfer [ERC20-FET] tokens from Ethereum Mainnet to [Native FET] tokens on Fetch\n         Native Mainnet-v2 and **other way around** (= it is bi-directional).\n         User will be *charged* swap fee defined in counterpart contract deployed on Fetch Native Mainnet-v2.\n         In the case of a refund, user will be charged a swap fee configured in this contract.\n         Swap Fees for `swap(...)` operations (direction from this contract to Native Fetch Mainnet-v2 are handled by\n         the counterpart contract on Fetch Native Mainnet-v2, **except** for refunds, for\n         which user is charged swap fee defined by this contract (since relayer needs to send refund transaction back\n         to this contract."
         },
         "fullyImplemented": false,
-        "id": 362,
+        "id": 453,
         "linearizedBaseContracts": [
-          362,
-          277
+          453,
+          368
         ],
         "name": "IBridgeRelayer",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "documentation": {
-              "id": 318,
+              "id": 409,
               "nodeType": "StructuredDocumentation",
-              "src": "2124:328:5",
+              "src": "2124:328:6",
               "text": " @notice Starts the new relay eon.\n @dev Relay eon concept is part of the design in order to ensure safe management of hand-over between two\n      relayer services. It provides clean isolation of potentially still pending transactions from previous\n      relayer svc and the current one."
             },
             "functionSelector": "c533c4c9",
-            "id": 321,
+            "id": 412,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "newRelayEon",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 319,
+              "id": 410,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2477:2:5"
+              "src": "2477:2:6"
             },
             "returnParameters": {
-              "id": 320,
+              "id": 411,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2488:0:5"
+              "src": "2488:0:6"
             },
-            "scope": 362,
-            "src": "2457:32:5",
+            "scope": 453,
+            "src": "2457:32:6",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 322,
+              "id": 413,
               "nodeType": "StructuredDocumentation",
-              "src": "2496:802:5",
+              "src": "2496:802:6",
               "text": " @notice Refunds swap previously created by `swap(...)` call to this contract. The `swapFee` is *NOT* refunded\n         back to the user (this is by-design).\n @dev Callable exclusively by `relayer` role\n @param id - swap id to refund - must be swap id of swap originally created by `swap(...)` call to this contract,\n             **NOT** *reverse* swap id!\n @param to - address where the refund will be transferred in to(IDENTICAL to address used in associated `swap`\n             call)\n @param amount - original amount specified in associated `swap` call = it INCLUDES swap fee, which will be\n                 withdrawn\n @param relayEon_ - current relay eon, ensures safe management of relaying process"
             },
             "functionSelector": "e779e30a",
-            "id": 333,
+            "id": 424,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "refund",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 331,
+              "id": 422,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 324,
+                  "id": 415,
                   "mutability": "mutable",
                   "name": "id",
                   "nodeType": "VariableDeclaration",
-                  "scope": 333,
-                  "src": "3319:9:5",
+                  "scope": 424,
+                  "src": "3319:9:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -763,10 +763,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 323,
+                    "id": 414,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3319:6:5",
+                    "src": "3319:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -776,12 +776,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 326,
+                  "id": 417,
                   "mutability": "mutable",
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 333,
-                  "src": "3330:10:5",
+                  "scope": 424,
+                  "src": "3330:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -789,10 +789,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 325,
+                    "id": 416,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3330:7:5",
+                    "src": "3330:7:6",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -803,12 +803,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 328,
+                  "id": 419,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 333,
-                  "src": "3342:14:5",
+                  "scope": 424,
+                  "src": "3342:14:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -816,10 +816,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 327,
+                    "id": 418,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3342:7:5",
+                    "src": "3342:7:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -829,12 +829,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 330,
+                  "id": 421,
                   "mutability": "mutable",
                   "name": "relayEon_",
                   "nodeType": "VariableDeclaration",
-                  "scope": 333,
-                  "src": "3358:16:5",
+                  "scope": 424,
+                  "src": "3358:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -842,10 +842,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 329,
+                    "id": 420,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "3358:6:5",
+                    "src": "3358:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -854,46 +854,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "3318:57:5"
+              "src": "3318:57:6"
             },
             "returnParameters": {
-              "id": 332,
+              "id": 423,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "3384:0:5"
+              "src": "3384:0:6"
             },
-            "scope": 362,
-            "src": "3303:82:5",
+            "scope": 453,
+            "src": "3303:82:6",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 334,
+              "id": 425,
               "nodeType": "StructuredDocumentation",
-              "src": "3392:1422:5",
+              "src": "3392:1422:6",
               "text": " @notice Refunds swap previously created by `swap(...)` call to this contract, where `swapFee` *IS* refunded\n         back to the user (= swap fee is waived = user will receive full `amount`).\n         Purpose of this method is to enable full refund in the situations when it si not user's fault that\n         swap needs to be refunded (e.g. when Fetch Native Mainnet-v2 will become unavailable for prolonged\n         period of time, etc. ...).\n @dev Callable exclusively by `relayer` role\n @param id - swap id to refund - must be swap id of swap originally created by `swap(...)` call to this contract,\n             **NOT** *reverse* swap id!\n @param to - address where the refund will be transferred in to(IDENTICAL to address used in associated `swap`\n             call)\n @param amount - original amount specified in associated `swap` call = it INCLUDES swap fee, which will be\n                 waived = user will receive whole `amount` value.\n                 Pleas mind that `amount > 0`, otherways relayer will pay Tx fee for executing the transaction\n                 which will have *NO* effect (= like this function `refundInFull(...)` would *not* have been\n                 called at all!\n @param relayEon_ - current relay eon, ensures safe management of relaying process"
             },
             "functionSelector": "ab2235a3",
-            "id": 345,
+            "id": 436,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "refundInFull",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 343,
+              "id": 434,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 336,
+                  "id": 427,
                   "mutability": "mutable",
                   "name": "id",
                   "nodeType": "VariableDeclaration",
-                  "scope": 345,
-                  "src": "4841:9:5",
+                  "scope": 436,
+                  "src": "4841:9:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -901,10 +901,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 335,
+                    "id": 426,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4841:6:5",
+                    "src": "4841:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -914,12 +914,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 338,
+                  "id": 429,
                   "mutability": "mutable",
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 345,
-                  "src": "4852:10:5",
+                  "scope": 436,
+                  "src": "4852:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -927,10 +927,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 337,
+                    "id": 428,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4852:7:5",
+                    "src": "4852:7:6",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -941,12 +941,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 340,
+                  "id": 431,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 345,
-                  "src": "4864:14:5",
+                  "scope": 436,
+                  "src": "4864:14:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -954,10 +954,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 339,
+                    "id": 430,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4864:7:5",
+                    "src": "4864:7:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -967,12 +967,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 342,
+                  "id": 433,
                   "mutability": "mutable",
                   "name": "relayEon_",
                   "nodeType": "VariableDeclaration",
-                  "scope": 345,
-                  "src": "4880:16:5",
+                  "scope": 436,
+                  "src": "4880:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -980,10 +980,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 341,
+                    "id": 432,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "4880:6:5",
+                    "src": "4880:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -992,46 +992,46 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "4840:57:5"
+              "src": "4840:57:6"
             },
             "returnParameters": {
-              "id": 344,
+              "id": 435,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "4906:0:5"
+              "src": "4906:0:6"
             },
-            "scope": 362,
-            "src": "4819:88:5",
+            "scope": 453,
+            "src": "4819:88:6",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           },
           {
             "documentation": {
-              "id": 346,
+              "id": 437,
               "nodeType": "StructuredDocumentation",
-              "src": "4914:2009:5",
+              "src": "4914:2009:6",
               "text": " @notice Finalises swap initiated by counterpart contract on the other blockchain.\n         This call sends swapped tokens to `to` address value user specified in original swap on the **OTHER**\n         blockchain.\n @dev Callable exclusively by `relayer` role\n @param rid - reverse swap id - unique identifier of the swap initiated on the **OTHER** blockchain.\n              This id is, by definition, sequentially growing number incremented by 1 for each new swap initiated\n              the other blockchain. **However**, it is *NOT* ensured that *all* swaps from the other blockchain\n              will be transferred to this (Ethereum) blockchain, since some of these swaps can be refunded back\n              to users (on the other blockchain).\n @param to - address where the refund will be transferred in to\n @param from - source address from which user transferred tokens from on the other blockchain. Present primarily\n               for purposes of quick querying of events on this blockchain.\n @param originTxHash - transaction hash for swap initiated on the **OTHER** blockchain. Present in order to\n                       create strong bond between this and other blockchain.\n @param amount - original amount specified in associated swap initiated on the other blockchain.\n                 Swap fee is *withdrawn* from the `amount` user specified in the swap on the other blockchain,\n                 what means that user receives `amount - swapFee`, or *nothing* if `amount <= swapFee`.\n                 Pleas mind that `amount > 0`, otherways relayer will pay Tx fee for executing the transaction\n                 which will have *NO* effect (= like this function `refundInFull(...)` would *not* have been\n                 called at all!\n @param relayEon_ - current relay eon, ensures safe management of relaying process"
             },
             "functionSelector": "e5c119ca",
-            "id": 361,
+            "id": 452,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "reverseSwap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 359,
+              "id": 450,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 348,
+                  "id": 439,
                   "mutability": "mutable",
                   "name": "rid",
                   "nodeType": "VariableDeclaration",
-                  "scope": 361,
-                  "src": "6958:10:5",
+                  "scope": 452,
+                  "src": "6958:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1039,10 +1039,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 347,
+                    "id": 438,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "6958:6:5",
+                    "src": "6958:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -1052,12 +1052,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 350,
+                  "id": 441,
                   "mutability": "mutable",
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 361,
-                  "src": "6978:10:5",
+                  "scope": 452,
+                  "src": "6978:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1065,10 +1065,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 349,
+                    "id": 440,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "6978:7:5",
+                    "src": "6978:7:6",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1079,12 +1079,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 352,
+                  "id": 443,
                   "mutability": "mutable",
                   "name": "from",
                   "nodeType": "VariableDeclaration",
-                  "scope": 361,
-                  "src": "6998:20:5",
+                  "scope": 452,
+                  "src": "6998:20:6",
                   "stateVariable": false,
                   "storageLocation": "calldata",
                   "typeDescriptions": {
@@ -1092,10 +1092,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 351,
+                    "id": 442,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "6998:6:5",
+                    "src": "6998:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -1105,12 +1105,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 354,
+                  "id": 445,
                   "mutability": "mutable",
                   "name": "originTxHash",
                   "nodeType": "VariableDeclaration",
-                  "scope": 361,
-                  "src": "7028:20:5",
+                  "scope": 452,
+                  "src": "7028:20:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1118,10 +1118,10 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 353,
+                    "id": 444,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
-                    "src": "7028:7:5",
+                    "src": "7028:7:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes32",
                       "typeString": "bytes32"
@@ -1131,12 +1131,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 356,
+                  "id": 447,
                   "mutability": "mutable",
                   "name": "amount",
                   "nodeType": "VariableDeclaration",
-                  "scope": 361,
-                  "src": "7058:14:5",
+                  "scope": 452,
+                  "src": "7058:14:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1144,10 +1144,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 355,
+                    "id": 446,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "7058:7:5",
+                    "src": "7058:7:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1157,12 +1157,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 358,
+                  "id": 449,
                   "mutability": "mutable",
                   "name": "relayEon_",
                   "nodeType": "VariableDeclaration",
-                  "scope": 361,
-                  "src": "7082:16:5",
+                  "scope": 452,
+                  "src": "7082:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1170,10 +1170,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 357,
+                    "id": 448,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "7082:6:5",
+                    "src": "7082:6:6",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -1182,26 +1182,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "6948:160:5"
+              "src": "6948:160:6"
             },
             "returnParameters": {
-              "id": 360,
+              "id": 451,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "7125:0:5"
+              "src": "7125:0:6"
             },
-            "scope": 362,
-            "src": "6928:198:5",
+            "scope": 453,
+            "src": "6928:198:6",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "external"
           }
         ],
-        "scope": 363,
-        "src": "2075:5053:5"
+        "scope": 454,
+        "src": "2075:5053:6"
       }
     ],
-    "src": "820:6309:5"
+    "src": "820:6309:6"
   },
   "contractName": "IBridgeRelayer",
   "dependencies": [

--- a/ethereum/interfaces/IAccessControl.sol
+++ b/ethereum/interfaces/IAccessControl.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier:Apache-2.0
+//------------------------------------------------------------------------------
+//
+//   Copyright 2021 Fetch.AI Limited
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+pragma solidity ^0.6.0 || ^0.7.0;
+
+
+/**
+ * @title Interface for AccessControl contract from OpenZeppelin
+ */
+interface IAccessControl {
+
+    /**
+     * @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`
+     *
+     * `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
+     * {RoleAdminChanged} not being emitted signaling this.
+     *
+     * _Available since v3.1._
+     */
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+
+    /**
+     * @dev Emitted when `account` is granted `role`.
+     *
+     * `sender` is the account that originated the contract call, an admin role
+     * bearer except when using {_setupRole}.
+     */
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Emitted when `account` is revoked `role`.
+     *
+     * `sender` is the account that originated the contract call:
+     *   - if using `revokeRole`, it is the admin role bearer
+     *   - if using `renounceRole`, it is the role bearer (i.e. `account`)
+     */
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) external view returns (bool);
+
+    /**
+     * @dev Returns the number of accounts that have `role`. Can be used
+     * together with {getRoleMember} to enumerate all bearers of a role.
+     */
+    function getRoleMemberCount(bytes32 role) external view returns (uint256);
+
+    /**
+     * @dev Returns one of the accounts that have `role`. `index` must be a
+     * value between 0 and {getRoleMemberCount}, non-inclusive.
+     *
+     * Role bearers are not sorted in any particular way, and their ordering may
+     * change at any point.
+     *
+     * WARNING: When using {getRoleMember} and {getRoleMemberCount}, make sure
+     * you perform all queries on the same block. See the following
+     * https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296[forum post]
+     * for more information.
+     */
+    function getRoleMember(bytes32 role, uint256 index) external view returns (address);
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) external view returns (bytes32);
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function grantRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function revokeRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been granted `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     */
+    function renounceRole(bytes32 role, address account) external;
+}


### PR DESCRIPTION
This does NOT affect Bridge contract code at all, it is just creation of additional interface for AccessControl OpenZeppelin contract, while that new interface is NOT used anywhere in Bridge contract or it;s dependencies, it is purely for external purposes (e.g. relayer service).

The only really relevant file is the `ethereum/interfaces/IAccessControl.sol` .