### PR TITLE
asi-migration preparation

### DIFF
--- a/fetch/cosmwasm_contract/.gitignore
+++ b/fetch/cosmwasm_contract/.gitignore
@@ -1,5 +1,6 @@
 # Build results
 /target
+/artifacts
 
 # Cargo+Git helper file (https://github.com/rust-lang/cargo/blob/0.44.1/src/cargo/sources/git/utils.rs#L320-L327)
 .cargo-ok

--- a/fetch/cosmwasm_contract/src/access_control.rs
+++ b/fetch/cosmwasm_contract/src/access_control.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, Order, StdError, StdResult, Storage};
 use cosmwasm_storage::{PrefixedStorage, ReadonlyPrefixedStorage};
 use std::str::FromStr;
 
@@ -94,4 +94,72 @@ pub fn ac_revoke_role(
         PrefixedStorage::multilevel(storage, &[ACCESS_CONTROL_KEY, addr.as_bytes()]);
     addr_roles.remove(role.as_bytes());
     Ok(true)
+}
+
+pub fn unsafe_remove_all_roles(storage: &mut dyn Storage) {
+    let mut roles_storage = PrefixedStorage::new(storage, ACCESS_CONTROL_KEY);
+    let res: Vec<_> = roles_storage.range(None, None, Order::Ascending).collect();
+
+    // Because address is stored as first key it is impossible to clear only specific roles without manually filtering it
+    for val in res {
+        roles_storage.remove(&val.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::mock_dependencies;
+
+    #[test]
+    fn test_unsafe_remove_all_roles() {
+        let mut deps = mock_dependencies();
+
+        let addresses = vec!["a", "b", "c", "d"];
+        let roles = vec![
+            AccessRole::Admin,
+            AccessRole::Approver,
+            AccessRole::Monitor,
+            AccessRole::Relayer,
+        ];
+
+        // Add every role and address combination
+        for address in &addresses {
+            for role in &roles {
+                ac_add_role(
+                    deps.as_mut().storage,
+                    &Addr::unchecked(address.to_string()),
+                    role,
+                )
+                .unwrap();
+            }
+        }
+
+        // Every role and address combination is present
+        for address in &addresses {
+            for role in &roles {
+                assert!(ac_have_role(
+                    deps.as_ref().storage,
+                    &Addr::unchecked(address.to_string()),
+                    role
+                )
+                .unwrap());
+            }
+        }
+
+        // Remove all roles
+        unsafe_remove_all_roles(deps.as_mut().storage);
+
+        // Every role and address combination was removed
+        for address in &addresses {
+            for role in &roles {
+                assert!(!ac_have_role(
+                    deps.as_ref().storage,
+                    &Addr::unchecked(address.to_string()),
+                    role
+                )
+                .unwrap());
+            }
+        }
+    }
 }

--- a/fetch/cosmwasm_contract/src/access_control.rs
+++ b/fetch/cosmwasm_contract/src/access_control.rs
@@ -102,7 +102,7 @@ pub fn unsafe_remove_all_roles(storage: &mut dyn Storage) {
 
     // Because address is stored as first key it is impossible to clear only specific roles without manually filtering it
     for val in res {
-        roles_storage.remove(&val.0)
+        roles_storage.remove(&val.0);
     }
 }
 

--- a/fetch/cosmwasm_contract/src/access_control.rs
+++ b/fetch/cosmwasm_contract/src/access_control.rs
@@ -96,7 +96,7 @@ pub fn ac_revoke_role(
     Ok(true)
 }
 
-pub fn unsafe_remove_all_roles(storage: &mut dyn Storage) {
+pub fn wipe_all_roles_from_storage(storage: &mut dyn Storage) {
     let mut roles_storage = PrefixedStorage::new(storage, ACCESS_CONTROL_KEY);
     let res: Vec<_> = roles_storage.range(None, None, Order::Ascending).collect();
 
@@ -112,7 +112,7 @@ mod tests {
     use cosmwasm_std::testing::mock_dependencies;
 
     #[test]
-    fn test_unsafe_remove_all_roles() {
+    fn test_wipe_all_roles_from_storage() {
         let mut deps = mock_dependencies();
 
         let addresses = vec!["a", "b", "c", "d"];
@@ -148,7 +148,7 @@ mod tests {
         }
 
         // Remove all roles
-        unsafe_remove_all_roles(deps.as_mut().storage);
+        wipe_all_roles_from_storage(deps.as_mut().storage);
 
         // Every role and address combination was removed
         for address in &addresses {

--- a/fetch/cosmwasm_contract/src/contract.rs
+++ b/fetch/cosmwasm_contract/src/contract.rs
@@ -19,6 +19,7 @@ use crate::state::{config, config_read, refunds_add, refunds_have, State};
 
 pub const DEFAULT_DENOM: &str = "aasi";
 pub const DEFAULT_RELAY_EON: u64 = 0;
+pub const DEFAULT_FEES_ACCRUED: Uint128 = Uint128::zero();
 
 /* ***************************************************
  * **************    Initialization      *************
@@ -38,6 +39,7 @@ pub fn instantiate(
         &info.sender,
         supply,
         DEFAULT_RELAY_EON,
+        DEFAULT_FEES_ACCRUED,
         &msg,
     )?;
 
@@ -50,6 +52,7 @@ pub fn initialise_contract_state(
     admin: &Addr,
     supply: Uint128,
     relay_eon: u64,
+    fees_accrued: Uint128,
     msg: &InstantiateMsg,
 ) -> StdResult<()> {
     let current_block_number = env.block.height;
@@ -70,7 +73,7 @@ pub fn initialise_contract_state(
 
     let state = State {
         supply,
-        fees_accrued: Uint128::zero(),
+        fees_accrued,
         next_swap_id: msg.next_swap_id,
         sealed_reverse_swap_id: 0,
         relay_eon,

--- a/fetch/cosmwasm_contract/src/contract.rs
+++ b/fetch/cosmwasm_contract/src/contract.rs
@@ -18,6 +18,7 @@ use crate::msg::{
 use crate::state::{config, config_read, refunds_add, refunds_have, State};
 
 pub const DEFAULT_DENOM: &str = "aasi";
+pub const DEFAULT_RELAY_EON: u64 = 0;
 
 /* ***************************************************
  * **************    Initialization      *************
@@ -30,7 +31,15 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
-    initialise_contract_state(deps.storage, &env, &info, &msg)?;
+    let supply = amount_from_funds(&info.funds, msg.get_denom()).unwrap_or(Uint128::zero());
+    initialise_contract_state(
+        deps.storage,
+        &env,
+        &info.sender,
+        supply,
+        DEFAULT_RELAY_EON,
+        &msg,
+    )?;
 
     Ok(Response::default())
 }
@@ -38,10 +47,11 @@ pub fn instantiate(
 pub fn initialise_contract_state(
     storage: &mut dyn Storage,
     env: &Env,
-    info: &MessageInfo,
+    admin: &Addr,
+    supply: Uint128,
+    relay_eon: u64,
     msg: &InstantiateMsg,
 ) -> StdResult<()> {
-    let env_message_sender = &info.sender;
     let current_block_number = env.block.height;
 
     let mut paused_since_block_public_api = msg.paused_since_block.unwrap_or(u64::MAX);
@@ -56,16 +66,14 @@ pub fn initialise_contract_state(
 
     let denom = msg.denom.as_deref().unwrap_or(DEFAULT_DENOM);
 
-    ac_add_role(storage, env_message_sender, &AccessRole::Admin)?;
-
-    let supply = amount_from_funds(&info.funds, denom);
+    ac_add_role(storage, admin, &AccessRole::Admin)?;
 
     let state = State {
-        supply: supply.unwrap_or_else(|_| Uint128::zero()),
+        supply,
         fees_accrued: Uint128::zero(),
         next_swap_id: msg.next_swap_id,
         sealed_reverse_swap_id: 0,
-        relay_eon: 0,
+        relay_eon,
         upper_swap_limit: msg.upper_swap_limit,
         lower_swap_limit: msg.lower_swap_limit,
         reverse_aggregated_allowance: msg.reverse_aggregated_allowance,

--- a/fetch/cosmwasm_contract/src/contract.rs
+++ b/fetch/cosmwasm_contract/src/contract.rs
@@ -30,7 +30,18 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
-    let env_message_sender = info.sender;
+    initialise_contract_state(deps.storage, &env, &info, &msg)?;
+
+    Ok(Response::default())
+}
+
+pub fn initialise_contract_state(
+    storage: &mut dyn Storage,
+    env: &Env,
+    info: &MessageInfo,
+    msg: &InstantiateMsg,
+) -> StdResult<()> {
+    let env_message_sender = &info.sender;
     let current_block_number = env.block.height;
 
     let mut paused_since_block_public_api = msg.paused_since_block.unwrap_or(u64::MAX);
@@ -39,17 +50,15 @@ pub fn instantiate(
     }
     let paused_since_block_relayer_api = paused_since_block_public_api;
 
-    let contract_addr_human = env.contract.address;
-
     if msg.lower_swap_limit > msg.upper_swap_limit || msg.lower_swap_limit <= msg.swap_fee {
         return Err(StdError::generic_err(ERR_SWAP_LIMITS_INCONSISTENT));
     }
 
-    let denom = msg.denom.unwrap_or_else(|| DEFAULT_DENOM.to_string());
+    let denom = msg.denom.as_deref().unwrap_or(DEFAULT_DENOM);
 
-    ac_add_role(deps.storage, &env_message_sender, &AccessRole::Admin)?;
+    ac_add_role(storage, env_message_sender, &AccessRole::Admin)?;
 
-    let supply = amount_from_funds(&info.funds, denom.clone());
+    let supply = amount_from_funds(&info.funds, denom);
 
     let state = State {
         supply: supply.unwrap_or_else(|_| Uint128::zero()),
@@ -65,13 +74,12 @@ pub fn instantiate(
         swap_fee: msg.swap_fee,
         paused_since_block_public_api,
         paused_since_block_relayer_api,
-        denom,
-        contract_addr_human, // optimization FIXME(LR) not needed any more (version 0.10.0)
+        denom: denom.to_string(),
     };
 
-    config(deps.storage).save(&state)?;
+    config(storage).save(&state)?;
 
-    Ok(Response::default())
+    Ok(())
 }
 
 /* ***************************************************
@@ -83,7 +91,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
 
     match msg {
         ExecuteMsg::Swap { destination } => {
-            let amount = amount_from_funds(&info.funds, state.denom.clone())?;
+            let amount = amount_from_funds(&info.funds, &state.denom)?;
             try_swap(deps, &env, &state, amount, destination)
         }
         ExecuteMsg::ReverseSwap {
@@ -481,7 +489,7 @@ fn try_deposit(deps: DepsMut, info: &MessageInfo, state: &State) -> StdResult<Re
 
     let env_message_sender = &info.sender;
 
-    let amount = amount_from_funds(&info.funds, state.denom.clone())?;
+    let amount = amount_from_funds(&info.funds, &state.denom)?;
     config(deps.storage).update(|mut state| -> StdResult<_> {
         state.supply += amount;
         Ok(state)
@@ -719,7 +727,7 @@ fn try_renounce_role(deps: DepsMut, info: &MessageInfo, role: String) -> StdResu
  * *****************    Helpers      *****************
  * ***************************************************/
 
-pub fn amount_from_funds(funds: &[Coin], denom: String) -> StdResult<Uint128> {
+pub fn amount_from_funds(funds: &[Coin], denom: &str) -> StdResult<Uint128> {
     for coin in funds {
         if coin.denom == denom {
             return Ok(coin.amount);

--- a/fetch/cosmwasm_contract/src/contract.rs
+++ b/fetch/cosmwasm_contract/src/contract.rs
@@ -32,7 +32,8 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
-    let supply = amount_from_funds(&info.funds, msg.get_denom()).unwrap_or(Uint128::zero());
+    let supply =
+        amount_from_funds(&info.funds, msg.get_denom()).unwrap_or_else(|_| Uint128::zero());
     initialise_contract_state(
         deps.storage,
         &env,

--- a/fetch/cosmwasm_contract/src/contract.rs
+++ b/fetch/cosmwasm_contract/src/contract.rs
@@ -17,7 +17,7 @@ use crate::msg::{
 };
 use crate::state::{config, config_read, refunds_add, refunds_have, State};
 
-pub const DEFAULT_DENOM: &str = "afet";
+pub const DEFAULT_DENOM: &str = "aasi";
 
 /* ***************************************************
  * **************    Initialization      *************

--- a/fetch/cosmwasm_contract/src/error.rs
+++ b/fetch/cosmwasm_contract/src/error.rs
@@ -30,6 +30,8 @@ pub const ERR_EON: &str = "[FET_ERR_EON] Tx doesn't belong to current relayEon";
 // refund
 pub const ERR_INVALID_SWAP_ID: &str = "[FET_ERR_INVALID_SWAP_ID] Invalid swap id";
 pub const ERR_ALREADY_REFUNDED: &str = "[FET_ERR_ALREADY_REFUNDED] Refund was already processed";
+pub const ERR_STATE_ERROR: &str = "[FET_ERR_STATE_ERR] Contract state not properly initialised";
+
 #[derive(Error, Debug)]
 pub enum ContractError {
     #[error("{0}")]

--- a/fetch/cosmwasm_contract/src/legacy_state.rs
+++ b/fetch/cosmwasm_contract/src/legacy_state.rs
@@ -1,0 +1,39 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::msg::Uint128;
+use cosmwasm_std::{Addr, Storage};
+use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
+
+pub static CONFIG_KEY: &[u8] = b"config";
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct LegacyState {
+    pub supply: Uint128,       // amount of token migrated to the other chain
+    pub fees_accrued: Uint128, // fees
+    pub next_swap_id: u64,
+    pub sealed_reverse_swap_id: u64,
+    pub relay_eon: u64,
+    pub upper_swap_limit: Uint128,
+    pub lower_swap_limit: Uint128,
+    pub reverse_aggregated_allowance: Uint128,
+    pub reverse_aggregated_allowance_approver_cap: Uint128,
+    pub cap: Uint128,
+    pub swap_fee: Uint128,
+    pub paused_since_block_public_api: u64,
+    pub paused_since_block_relayer_api: u64,
+    pub denom: String,
+
+    // optimization FIXME(LR) Not needed any more with version 0.10.0
+    pub contract_addr_human: Addr,
+}
+
+pub fn legacy_config_read(storage: &dyn Storage) -> ReadonlySingleton<LegacyState> {
+    singleton_read(storage, CONFIG_KEY)
+}
+
+#[allow(dead_code)]
+pub fn legacy_config(storage: &mut dyn Storage) -> Singleton<LegacyState> {
+    singleton(storage, crate::state::CONFIG_KEY)
+}

--- a/fetch/cosmwasm_contract/src/lib.rs
+++ b/fetch/cosmwasm_contract/src/lib.rs
@@ -4,5 +4,6 @@ pub mod error;
 pub mod msg;
 pub mod state;
 
+pub mod migration;
 #[cfg(test)]
 pub mod tests;

--- a/fetch/cosmwasm_contract/src/lib.rs
+++ b/fetch/cosmwasm_contract/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod msg;
 pub mod state;
 
+mod legacy_state;
 pub mod migration;
 #[cfg(test)]
 pub mod tests;

--- a/fetch/cosmwasm_contract/src/migration.rs
+++ b/fetch/cosmwasm_contract/src/migration.rs
@@ -1,6 +1,7 @@
 use crate::access_control::wipe_all_roles_from_storage;
 use crate::contract::initialise_contract_state;
-use crate::error::ERR_ALREADY_REFUNDED;
+use crate::error::ERR_STATE_ERROR;
+use crate::legacy_state::legacy_config_read;
 use crate::msg::MigrateMsg;
 use crate::state::is_state_valid;
 use cosmwasm_std::{entry_point, DepsMut, Env, Response, StdError, StdResult};
@@ -10,20 +11,118 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
     // Remove all previously registered roles
     wipe_all_roles_from_storage(deps.storage);
 
+    let legacy_state = legacy_config_read(deps.storage).load()?;
+
     // Ensure correct contract state
     if let Some(re_init) = msg.re_init {
         initialise_contract_state(
             deps.storage,
             &env,
             &re_init.admin,
-            re_init.supply,
-            re_init.relay_eon,
-            re_init.fees_accrued,
+            legacy_state.supply,
+            legacy_state.relay_eon,
+            legacy_state.fees_accrued,
             &re_init.init_msg,
         )?;
     } else if !is_state_valid(deps.storage) {
-        return Err(StdError::generic_err(ERR_ALREADY_REFUNDED));
+        return Err(StdError::generic_err(ERR_STATE_ERROR));
     }
 
     Ok(Response::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::legacy_state::{legacy_config, LegacyState};
+    use crate::msg::{InstantiateMsg, ReInitMsg};
+    use crate::state::config_read;
+    use cosmwasm_std::testing::mock_dependencies;
+    use cosmwasm_std::{Addr, Uint128};
+    use cosmwasm_vm::testing::mock_env;
+
+    #[test]
+    fn test_can_migrate() {
+        let mut deps = mock_dependencies();
+
+        // Prepare legacy storage
+        let legacy_state = LegacyState {
+            supply: Uint128::new(1),
+            fees_accrued: Uint128::new(2),
+            next_swap_id: 3,
+            sealed_reverse_swap_id: 4,
+            relay_eon: 5,
+            upper_swap_limit: Uint128::new(7),
+            lower_swap_limit: Uint128::new(6),
+            reverse_aggregated_allowance: Uint128::new(8),
+            reverse_aggregated_allowance_approver_cap: Uint128::new(9),
+            cap: Uint128::new(10),
+            swap_fee: Uint128::new(2),
+            paused_since_block_public_api: 12,
+            paused_since_block_relayer_api: 13,
+            denom: "ABC".to_string(),
+            contract_addr_human: Addr::unchecked("DEF"),
+        };
+        assert!(legacy_config(deps.as_mut().storage)
+            .save(&legacy_state)
+            .is_ok());
+
+        let admin = Addr::unchecked("admin");
+        let init_msg = InstantiateMsg {
+            next_swap_id: 10,
+            cap: Uint128::new(20),
+            upper_swap_limit: Uint128::new(40),
+            lower_swap_limit: Uint128::new(30),
+            swap_fee: Uint128::new(10),
+            reverse_aggregated_allowance: Uint128::new(60),
+            reverse_aggregated_allowance_approver_cap: Uint128::new(70),
+            paused_since_block: Some(80),
+            denom: Some("ASI".to_string()),
+        };
+
+        let re_init_msg = ReInitMsg {
+            init_msg: init_msg.clone(),
+            admin: admin.clone(),
+        };
+
+        let migrate_msg = MigrateMsg {
+            re_init: Some(re_init_msg),
+        };
+
+        let mut env = mock_env();
+        env.block.height = 1;
+        assert!(migrate(deps.as_mut(), env, migrate_msg).is_ok());
+
+        let new_state = config_read(deps.as_ref().storage).load().unwrap();
+
+        // Transferred legacy values
+        assert_eq!(new_state.supply, legacy_state.supply);
+        assert_eq!(new_state.relay_eon, legacy_state.relay_eon);
+        assert_eq!(new_state.fees_accrued, legacy_state.fees_accrued);
+
+        // New values
+        assert_eq!(new_state.cap, init_msg.cap);
+        assert_eq!(new_state.denom, init_msg.denom.unwrap());
+        assert_eq!(new_state.next_swap_id, init_msg.next_swap_id);
+        assert_eq!(new_state.lower_swap_limit, init_msg.lower_swap_limit);
+        assert_eq!(
+            new_state.paused_since_block_public_api,
+            init_msg.paused_since_block.unwrap()
+        );
+        assert_eq!(
+            new_state.paused_since_block_relayer_api,
+            init_msg.paused_since_block.unwrap()
+        );
+        assert_eq!(
+            new_state.reverse_aggregated_allowance,
+            init_msg.reverse_aggregated_allowance
+        );
+        assert_eq!(
+            new_state.reverse_aggregated_allowance_approver_cap,
+            init_msg.reverse_aggregated_allowance_approver_cap
+        );
+        assert_eq!(new_state.sealed_reverse_swap_id, 0);
+        assert_eq!(new_state.swap_fee, init_msg.swap_fee);
+        assert_eq!(new_state.upper_swap_limit, init_msg.upper_swap_limit);
+    }
 }

--- a/fetch/cosmwasm_contract/src/migration.rs
+++ b/fetch/cosmwasm_contract/src/migration.rs
@@ -1,18 +1,25 @@
-use crate::access_control::unsafe_remove_all_roles;
+use crate::access_control::wipe_all_roles_from_storage;
 use crate::contract::initialise_contract_state;
 use crate::error::ERR_ALREADY_REFUNDED;
 use crate::msg::MigrateMsg;
 use crate::state::is_state_valid;
-use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, Response, StdError, StdResult};
+use cosmwasm_std::{entry_point, DepsMut, Env, Response, StdError, StdResult};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, env: Env, info: MessageInfo, msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
     // Remove all previously registered roles
-    unsafe_remove_all_roles(deps.storage);
+    wipe_all_roles_from_storage(deps.storage);
 
     // Ensure correct contract state
-    if let Some(msg) = msg.instantiate_msg {
-        initialise_contract_state(deps.storage, &env, &info, &msg)?;
+    if let Some(re_init) = msg.re_init {
+        initialise_contract_state(
+            deps.storage,
+            &env,
+            &re_init.admin,
+            re_init.supply,
+            re_init.relay_eon,
+            &re_init.init_msg,
+        )?;
     } else if !is_state_valid(deps.storage) {
         return Err(StdError::generic_err(ERR_ALREADY_REFUNDED));
     }

--- a/fetch/cosmwasm_contract/src/migration.rs
+++ b/fetch/cosmwasm_contract/src/migration.rs
@@ -18,6 +18,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
             &re_init.admin,
             re_init.supply,
             re_init.relay_eon,
+            re_init.fees_accrued,
             &re_init.init_msg,
         )?;
     } else if !is_state_valid(deps.storage) {

--- a/fetch/cosmwasm_contract/src/migration.rs
+++ b/fetch/cosmwasm_contract/src/migration.rs
@@ -1,0 +1,21 @@
+use crate::access_control::unsafe_remove_all_roles;
+use crate::contract::initialise_contract_state;
+use crate::error::ERR_ALREADY_REFUNDED;
+use crate::msg::MigrateMsg;
+use crate::state::is_state_valid;
+use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, Response, StdError, StdResult};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, env: Env, info: MessageInfo, msg: MigrateMsg) -> StdResult<Response> {
+    // Remove all previously registered roles
+    unsafe_remove_all_roles(deps.storage);
+
+    // Ensure correct contract state
+    if let Some(msg) = msg.instantiate_msg {
+        initialise_contract_state(deps.storage, &env, &info, &msg)?;
+    } else if !is_state_valid(deps.storage) {
+        return Err(StdError::generic_err(ERR_ALREADY_REFUNDED));
+    }
+
+    Ok(Response::default())
+}

--- a/fetch/cosmwasm_contract/src/msg.rs
+++ b/fetch/cosmwasm_contract/src/msg.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::contract::DEFAULT_DENOM;
 use cosmwasm_std::Addr;
 
 //use crate::cosmwasm_bignumber::{Uint256};
@@ -18,6 +19,12 @@ pub struct InstantiateMsg {
     pub reverse_aggregated_allowance_approver_cap: Uint128,
     pub paused_since_block: Option<u64>,
     pub denom: Option<String>,
+}
+
+impl InstantiateMsg {
+    pub fn get_denom(&self) -> &str {
+        self.denom.as_deref().unwrap_or(DEFAULT_DENOM)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -156,7 +163,15 @@ pub struct DenomResponse {
     pub denom: String,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ReInitMsg {
+    pub init_msg: InstantiateMsg,
+    pub admin: Addr,
+    pub supply: Uint128,
+    pub relay_eon: u64,
+}
+
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct MigrateMsg {
-    pub instantiate_msg: Option<InstantiateMsg>,
+    pub re_init: Option<ReInitMsg>,
 }

--- a/fetch/cosmwasm_contract/src/msg.rs
+++ b/fetch/cosmwasm_contract/src/msg.rs
@@ -169,6 +169,7 @@ pub struct ReInitMsg {
     pub admin: Addr,
     pub supply: Uint128,
     pub relay_eon: u64,
+    pub fees_accrued: Uint128,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]

--- a/fetch/cosmwasm_contract/src/msg.rs
+++ b/fetch/cosmwasm_contract/src/msg.rs
@@ -155,3 +155,8 @@ pub struct PausedSinceBlockResponse {
 pub struct DenomResponse {
     pub denom: String,
 }
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct MigrateMsg {
+    pub instantiate_msg: Option<InstantiateMsg>,
+}

--- a/fetch/cosmwasm_contract/src/msg.rs
+++ b/fetch/cosmwasm_contract/src/msg.rs
@@ -167,9 +167,6 @@ pub struct DenomResponse {
 pub struct ReInitMsg {
     pub init_msg: InstantiateMsg,
     pub admin: Addr,
-    pub supply: Uint128,
-    pub relay_eon: u64,
-    pub fees_accrued: Uint128,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]

--- a/fetch/cosmwasm_contract/src/state.rs
+++ b/fetch/cosmwasm_contract/src/state.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::msg::Uint128;
-use cosmwasm_std::{Addr, Storage};
+use cosmwasm_std::Storage;
 use cosmwasm_storage::{
     singleton, singleton_read, PrefixedStorage, ReadonlyPrefixedStorage, ReadonlySingleton,
     Singleton,
@@ -28,9 +28,6 @@ pub struct State {
     pub paused_since_block_public_api: u64,
     pub paused_since_block_relayer_api: u64,
     pub denom: String,
-
-    // optimization FIXME(LR) Not needed any more with version 0.10.0
-    pub contract_addr_human: Addr,
 }
 
 pub fn config(storage: &mut dyn Storage) -> Singleton<State> {
@@ -49,4 +46,8 @@ pub fn refunds_add(swap_id: u64, storage: &mut dyn Storage) {
 pub fn refunds_have(swap_id: u64, storage: &dyn Storage) -> bool {
     let store = ReadonlyPrefixedStorage::new(storage, REFUNDS_KEY);
     store.get(&swap_id.to_be_bytes()).is_some()
+}
+
+pub fn is_state_valid(storage: &dyn Storage) -> bool {
+    config_read(storage).load().is_ok()
 }

--- a/fetch/cosmwasm_contract/src/tests.rs
+++ b/fetch/cosmwasm_contract/src/tests.rs
@@ -24,7 +24,7 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, Uint128};
 use crate::state::{config_read, State};
 
 pub const DEFAULT_OWNER: &str = "Owner";
-pub const DEFAULT_DENOM: &str = "atestfet";
+pub const DEFAULT_DENOM: &str = "atestasi";
 pub const DEFAULT_CAP: u128 = 100000u128;
 pub const DEFAULT_RA_ALLOWANCE: u128 = 10000u128;
 pub const DEFAULT_RA_ALLOWANCE_APPROVER_CAP: u128 = 5000u128;
@@ -928,10 +928,10 @@ mod swap {
         let mut deps = mock_dependencies();
         init_default(&mut deps).unwrap();
 
-        let fet_account = "user_account";
+        let native_account = "user_account";
         let eth_account = "some_eth_account";
         let amount = 110u128;
-        let response = swap(deps.as_mut(), fet_account, eth_account, amount).unwrap();
+        let response = swap(deps.as_mut(), native_account, eth_account, amount).unwrap();
 
         // check handle response
         assert_eq!(0, response.messages.len());
@@ -966,7 +966,7 @@ mod swap {
         let mut deps = mock_dependencies();
         init_default(&mut deps).unwrap();
 
-        let fet_account = "user_account";
+        let native_account = "user_account";
         let eth_account = "some_eth_account";
         let mut amount: u128;
         let msg = ExecuteMsg::Swap {
@@ -974,12 +974,12 @@ mod swap {
         };
 
         amount = DEFAULT_SWAP_LOWER_LIMIT - 10u128;
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
+        let info = mock_info(native_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_SWAP_LIMITS_VIOLATED);
 
         amount = DEFAULT_SWAP_UPPER_LIMIT + 10u128;
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
+        let info = mock_info(native_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_SWAP_LIMITS_VIOLATED);
 
@@ -994,7 +994,7 @@ mod swap {
         let mut deps = mock_dependencies();
         init_default(&mut deps).unwrap();
 
-        let fet_account = "user_account";
+        let native_account = "user_account";
         let eth_account = "some_eth_account";
         let amount = DEFAULT_SWAP_UPPER_LIMIT;
         let msg = ExecuteMsg::Swap {
@@ -1002,11 +1002,11 @@ mod swap {
         };
 
         for _ in 0..(DEFAULT_CAP / DEFAULT_SWAP_UPPER_LIMIT) {
-            let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
+            let info = mock_info(native_account, &coins(amount, DEFAULT_DENOM));
             execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap();
         }
 
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
+        let info = mock_info(native_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_CAP_EXCEEDED);
 
@@ -1023,14 +1023,14 @@ mod swap {
         let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENOM));
         pause_public_api(&mut deps, info).unwrap();
 
-        let fet_account = "user_account";
+        let native_account = "user_account";
         let eth_account = "some_eth_account";
         let amount = DEFAULT_SWAP_UPPER_LIMIT;
         let msg = ExecuteMsg::Swap {
             destination: eth_account.to_string(),
         };
 
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
+        let info = mock_info(native_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_CONTRACT_PAUSED);
 
@@ -1092,7 +1092,7 @@ mod reverse_swap {
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
 
-        let fet_account = "user_account";
+        let native_account = "user_account";
         let eth_account = "some_eth_account";
         let amount = 110u128;
         let rid = 0u64;
@@ -1102,7 +1102,7 @@ mod reverse_swap {
             deps.as_mut(),
             relayer,
             rid,
-            fet_account,
+            native_account,
             eth_account,
             origin_tx_hash,
             amount,
@@ -1119,7 +1119,7 @@ mod reverse_swap {
                     to_address,
                     amount: funds,
                 } => {
-                    assert_eq!(&addr!(fet_account), to_address);
+                    assert_eq!(&addr!(native_account), to_address);
                     assert_eq!(
                         cu128!(amount - DEFAULT_SWAP_FEE),
                         amount_from_funds(funds, DEFAULT_DENOM).unwrap()
@@ -1136,7 +1136,9 @@ mod reverse_swap {
         assert!(
             response.attributes[1].key == "rid" && response.attributes[1].value == rid.to_string()
         );
-        assert!(response.attributes[2].key == "to" && response.attributes[2].value == fet_account);
+        assert!(
+            response.attributes[2].key == "to" && response.attributes[2].value == native_account
+        );
         assert!(
             response.attributes[3].key == "sender" && response.attributes[3].value == eth_account
         );
@@ -1354,12 +1356,12 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 1000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
         swap(
             deps.as_mut(),
-            fet_account,
+            native_account,
             "some_eth_account",
             DEFAULT_SWAP_LOWER_LIMIT,
         )
@@ -1370,10 +1372,10 @@ mod refund {
         let eon = 0u64;
         let response: Response;
         if fee > 0 {
-            response = refund(deps.as_mut(), relayer, id, fet_account, amount, eon).unwrap();
+            response = refund(deps.as_mut(), relayer, id, native_account, amount, eon).unwrap();
         } else {
             response =
-                refund_in_full(deps.as_mut(), relayer, id, fet_account, amount, eon).unwrap();
+                refund_in_full(deps.as_mut(), relayer, id, native_account, amount, eon).unwrap();
         }
 
         // check handle response
@@ -1385,7 +1387,7 @@ mod refund {
                     to_address,
                     amount: funds,
                 } => {
-                    assert_eq!(&addr!(fet_account), to_address);
+                    assert_eq!(&addr!(native_account), to_address);
                     assert_eq!(
                         cu128!(amount - fee),
                         amount_from_funds(funds, DEFAULT_DENOM).unwrap()
@@ -1398,7 +1400,7 @@ mod refund {
         assert!(response.attributes[0].key == "action" && response.attributes[0].value == "refund");
         assert!(
             response.attributes[1].key == "destination"
-                && response.attributes[1].value == fet_account
+                && response.attributes[1].value == native_account
         );
         assert!(
             response.attributes[2].key == "swap_id"
@@ -1443,12 +1445,12 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 1000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
         swap(
             deps.as_mut(),
-            fet_account,
+            native_account,
             "some_eth_account",
             DEFAULT_SWAP_LOWER_LIMIT,
         )
@@ -1458,7 +1460,7 @@ mod refund {
         let amount = DEFAULT_SWAP_LOWER_LIMIT + 10u128;
         let id = 0u64;
         let eon = 0u64;
-        let response = refund(deps.as_mut(), not_relayer, id, fet_account, amount, eon);
+        let response = refund(deps.as_mut(), not_relayer, id, native_account, amount, eon);
         expect_error!(response, ERR_ACCESS_CONTROL_ONLY_RELAYER);
     }
 
@@ -1469,12 +1471,12 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 1000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
         swap(
             deps.as_mut(),
-            fet_account,
+            native_account,
             "some_eth_account",
             DEFAULT_SWAP_LOWER_LIMIT,
         )
@@ -1484,7 +1486,7 @@ mod refund {
         let amount = DEFAULT_SWAP_LOWER_LIMIT + 10u128;
         let id = 0u64;
         let eon = 0u64;
-        let response = refund(deps.as_mut(), relayer, id, fet_account, amount, eon);
+        let response = refund(deps.as_mut(), relayer, id, native_account, amount, eon);
         expect_error!(response, ERR_EON);
     }
 
@@ -1495,12 +1497,12 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 1000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
         swap(
             deps.as_mut(),
-            fet_account,
+            native_account,
             "some_eth_account",
             DEFAULT_SWAP_LOWER_LIMIT,
         )
@@ -1511,7 +1513,7 @@ mod refund {
         let amount = DEFAULT_SWAP_LOWER_LIMIT + 10u128;
         let id = 0u64;
         let eon = 0u64;
-        let response = refund(deps.as_mut(), relayer, id, fet_account, amount, eon);
+        let response = refund(deps.as_mut(), relayer, id, native_account, amount, eon);
         expect_error!(response, ERR_CONTRACT_PAUSED);
     }
 
@@ -1522,14 +1524,14 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 1000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
 
         let amount = DEFAULT_SWAP_LOWER_LIMIT + 10u128;
         let id = 0u64;
         let eon = 0u64;
-        let response = refund(deps.as_mut(), relayer, id, fet_account, amount, eon);
+        let response = refund(deps.as_mut(), relayer, id, native_account, amount, eon);
         expect_error!(response, ERR_INVALID_SWAP_ID);
     }
 
@@ -1540,12 +1542,12 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 1000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
         swap(
             deps.as_mut(),
-            fet_account,
+            native_account,
             "some_eth_account",
             DEFAULT_SWAP_LOWER_LIMIT,
         )
@@ -1554,8 +1556,8 @@ mod refund {
         let amount = DEFAULT_SWAP_LOWER_LIMIT + 10u128;
         let id = 0u64;
         let eon = 0u64;
-        refund(deps.as_mut(), relayer, id, fet_account, amount, eon).unwrap();
-        let response = refund(deps.as_mut(), relayer, id, fet_account, amount, eon);
+        refund(deps.as_mut(), relayer, id, native_account, amount, eon).unwrap();
+        let response = refund(deps.as_mut(), relayer, id, native_account, amount, eon);
         expect_error!(response, ERR_ALREADY_REFUNDED);
     }
 
@@ -1566,7 +1568,7 @@ mod refund {
 
         let relayer = "new_relayer";
         let deposited = 10000u128;
-        let fet_account = "user_account";
+        let native_account = "user_account";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
 
@@ -1575,7 +1577,7 @@ mod refund {
         for _ in 0..(DEFAULT_RA_ALLOWANCE / DEFAULT_SWAP_UPPER_LIMIT) {
             swap(
                 deps.as_mut(),
-                fet_account,
+                native_account,
                 "some_eth_account",
                 DEFAULT_SWAP_LOWER_LIMIT,
             )
@@ -1584,7 +1586,7 @@ mod refund {
                 deps.as_mut(),
                 relayer,
                 id,
-                fet_account,
+                native_account,
                 DEFAULT_SWAP_UPPER_LIMIT,
                 eon,
             )
@@ -1594,7 +1596,7 @@ mod refund {
 
         swap(
             deps.as_mut(),
-            fet_account,
+            native_account,
             "some_eth_account",
             DEFAULT_SWAP_LOWER_LIMIT,
         )
@@ -1603,7 +1605,7 @@ mod refund {
             deps.as_mut(),
             relayer,
             id,
-            fet_account,
+            native_account,
             DEFAULT_SWAP_UPPER_LIMIT,
             eon,
         );

--- a/fetch/cosmwasm_contract/src/tests.rs
+++ b/fetch/cosmwasm_contract/src/tests.rs
@@ -24,7 +24,7 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, Uint128};
 use crate::state::{config_read, State};
 
 pub const DEFAULT_OWNER: &str = "Owner";
-pub const DEFAULT_DENUM: &str = "atestfet";
+pub const DEFAULT_DENOM: &str = "atestfet";
 pub const DEFAULT_CAP: u128 = 100000u128;
 pub const DEFAULT_RA_ALLOWANCE: u128 = 10000u128;
 pub const DEFAULT_RA_ALLOWANCE_APPROVER_CAP: u128 = 5000u128;
@@ -75,7 +75,7 @@ mod init {
         caller: &str,
         amount: u128,
     ) -> StdResult<Response> {
-        let info = mock_info(caller, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(amount, DEFAULT_DENOM));
         return instantiate(deps.as_mut(), mock_env(), info, msg);
     }
 
@@ -90,7 +90,7 @@ mod init {
             lower_swap_limit: cu128!(DEFAULT_SWAP_LOWER_LIMIT),
             swap_fee: cu128!(DEFAULT_SWAP_FEE),
             paused_since_block: None,
-            denom: Some(DEFAULT_DENUM.to_string()),
+            denom: Some(DEFAULT_DENOM.to_string()),
             next_swap_id: 0,
         };
         return mock_init(deps, msg, DEFAULT_OWNER, 0);
@@ -120,8 +120,7 @@ mod init {
             swap_fee: cu128!(DEFAULT_SWAP_FEE),
             paused_since_block_public_api: u64::MAX,
             paused_since_block_relayer_api: u64::MAX,
-            denom: DEFAULT_DENUM.to_string(),
-            contract_addr_human: mock_env().contract.address,
+            denom: DEFAULT_DENOM.to_string(),
         };
 
         let state = config_read(&deps.storage)
@@ -191,7 +190,7 @@ mod access_control {
             role: String::from(role),
             address: addr!(account),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -237,7 +236,7 @@ mod access_control {
             role: String::from(role),
             address: addr!(account),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -281,7 +280,7 @@ mod access_control {
         let msg = ExecuteMsg::RenounceRole {
             role: String::from(role),
         };
-        let info = mock_info(account, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(account, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -551,7 +550,7 @@ mod pause {
     }
 
     fn assert_pause_both(deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>, caller: &str) {
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         assert!(verify_not_paused_public_api(
             &mock_env(),
             &config_read(&deps.storage).load().unwrap()
@@ -669,7 +668,7 @@ mod pause {
         init_default(&mut deps).unwrap();
 
         let caller = DEFAULT_OWNER;
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         pause_public_api(&mut deps, info.clone()).unwrap();
         pause_relayer_api(&mut deps, info.clone()).unwrap();
 
@@ -729,7 +728,7 @@ mod pause {
         init_default(&mut deps).unwrap();
 
         let caller = "user";
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
 
         let mut response = pause_public_api(&mut deps, info.clone());
         expect_error!(response, ERR_ACCESS_CONTROL_ONLY_ADMIN);
@@ -746,7 +745,7 @@ mod pause {
         let monitor = "new_monitor";
         grant_role(&mut deps, MONITOR_ROLE, monitor, DEFAULT_OWNER).unwrap();
 
-        let info = mock_info(monitor, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(monitor, &coins(0, DEFAULT_DENOM));
         pause_public_api(&mut deps, info.clone()).unwrap();
         pause_relayer_api(&mut deps, info.clone()).unwrap();
 
@@ -778,7 +777,7 @@ mod deposit {
         caller: &str,
     ) -> StdResult<Response> {
         let msg = ExecuteMsg::Deposit {};
-        let info = mock_info(caller, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(amount, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -847,7 +846,7 @@ mod new_relay_eon {
         caller: &str,
     ) -> StdResult<Response> {
         let msg = ExecuteMsg::NewRelayEon {};
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -899,7 +898,7 @@ mod new_relay_eon {
 
         let relayer = "new_relayer";
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
-        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENOM));
         pause_relayer_api(&mut deps, info).unwrap();
 
         let response = new_relay_eon(&mut deps, relayer);
@@ -920,7 +919,7 @@ mod swap {
             destination: destination.to_string(),
         };
 
-        let info = mock_info(from, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(from, &coins(amount, DEFAULT_DENOM));
         execute(deps, mock_env(), info, msg)
     }
 
@@ -975,12 +974,12 @@ mod swap {
         };
 
         amount = DEFAULT_SWAP_LOWER_LIMIT - 10u128;
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_SWAP_LIMITS_VIOLATED);
 
         amount = DEFAULT_SWAP_UPPER_LIMIT + 10u128;
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_SWAP_LIMITS_VIOLATED);
 
@@ -1003,11 +1002,11 @@ mod swap {
         };
 
         for _ in 0..(DEFAULT_CAP / DEFAULT_SWAP_UPPER_LIMIT) {
-            let info = mock_info(fet_account, &coins(amount, DEFAULT_DENUM));
+            let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
             execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap();
         }
 
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_CAP_EXCEEDED);
 
@@ -1021,7 +1020,7 @@ mod swap {
         let mut deps = mock_dependencies();
         init_default(&mut deps).unwrap();
 
-        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENOM));
         pause_public_api(&mut deps, info).unwrap();
 
         let fet_account = "user_account";
@@ -1031,7 +1030,7 @@ mod swap {
             destination: eth_account.to_string(),
         };
 
-        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENUM));
+        let info = mock_info(fet_account, &coins(amount, DEFAULT_DENOM));
         let response = execute(deps.as_mut(), mock_env(), info, msg.clone());
         expect_error!(response, ERR_CONTRACT_PAUSED);
 
@@ -1069,7 +1068,7 @@ mod reverse_swap {
             relay_eon: eon,
         };
 
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps, mock_env(), info.clone(), msg)
     }
 
@@ -1123,7 +1122,7 @@ mod reverse_swap {
                     assert_eq!(&addr!(fet_account), to_address);
                     assert_eq!(
                         cu128!(amount - DEFAULT_SWAP_FEE),
-                        amount_from_funds(funds, DEFAULT_DENUM.to_string()).unwrap()
+                        amount_from_funds(funds, DEFAULT_DENOM).unwrap()
                     );
                 }
                 _ => panic!("unexpected bank message in handle response"),
@@ -1223,7 +1222,7 @@ mod reverse_swap {
         let deposited = 1000u128;
         grant_role(&mut deps, RELAYER_ROLE, relayer, DEFAULT_OWNER).unwrap();
         deposit(&mut deps, deposited, DEFAULT_OWNER).unwrap();
-        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENOM));
         pause_relayer_api(&mut deps, info).unwrap();
 
         let response = reverse_swap(
@@ -1326,7 +1325,7 @@ mod refund {
             relay_eon: eon,
         };
 
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps, mock_env(), info, msg)
     }
 
@@ -1345,7 +1344,7 @@ mod refund {
             relay_eon: eon,
         };
 
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps, mock_env(), info, msg)
     }
 
@@ -1389,7 +1388,7 @@ mod refund {
                     assert_eq!(&addr!(fet_account), to_address);
                     assert_eq!(
                         cu128!(amount - fee),
-                        amount_from_funds(funds, DEFAULT_DENUM.to_string()).unwrap()
+                        amount_from_funds(funds, DEFAULT_DENOM).unwrap()
                     );
                 }
                 _ => panic!("unexpected bank message in handle response"),
@@ -1506,7 +1505,7 @@ mod refund {
             DEFAULT_SWAP_LOWER_LIMIT,
         )
         .unwrap();
-        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(DEFAULT_OWNER, &coins(0, DEFAULT_DENOM));
         pause_relayer_api(&mut deps, info).unwrap();
 
         let amount = DEFAULT_SWAP_LOWER_LIMIT + 10u128;
@@ -1623,7 +1622,7 @@ mod withdraw {
             amount: cu128!(amount),
             destination: addr!(recipient),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps, mock_env(), info, msg)
     }
 
@@ -1651,7 +1650,7 @@ mod withdraw {
                     assert_eq!(&addr!(recipient), to_address);
                     assert_eq!(
                         cu128!(2 * amount),
-                        amount_from_funds(funds, DEFAULT_DENUM.to_string()).unwrap()
+                        amount_from_funds(funds, DEFAULT_DENOM).unwrap()
                     );
                 }
                 _ => panic!("unexpected bank message in handle response"),
@@ -1721,7 +1720,7 @@ mod withdraw_fees {
             amount: cu128!(amount),
             destination: addr!(recipient),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps, mock_env(), info, msg)
     }
 
@@ -1765,7 +1764,7 @@ mod withdraw_fees {
                     assert_eq!(&addr!(recipient), to_address);
                     assert_eq!(
                         cu128!(DEFAULT_SWAP_FEE),
-                        amount_from_funds(funds, DEFAULT_DENUM.to_string()).unwrap()
+                        amount_from_funds(funds, DEFAULT_DENOM).unwrap()
                     );
                 }
                 _ => panic!("unexpected bank message in handle response"),
@@ -1835,7 +1834,7 @@ mod set_cap {
         let msg = ExecuteMsg::SetCap {
             amount: cu128!(amount),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -1901,7 +1900,7 @@ mod set_limits {
             swap_max: cu128!(max),
             swap_fee: cu128!(fee),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps, mock_env(), info, msg)
     }
 
@@ -1997,7 +1996,7 @@ mod set_reverse_aggregated_allowance {
         let msg = ExecuteMsg::SetReverseAggregatedAllowance {
             amount: cu128!(amount),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 
@@ -2009,7 +2008,7 @@ mod set_reverse_aggregated_allowance {
         let msg = ExecuteMsg::SetReverseAggregatedAllowanceApproverCap {
             amount: cu128!(amount),
         };
-        let info = mock_info(caller, &coins(0, DEFAULT_DENUM));
+        let info = mock_info(caller, &coins(0, DEFAULT_DENOM));
         execute(deps.as_mut(), mock_env(), info, msg)
     }
 


### PR DESCRIPTION
- Renamed defaults `atestfet`/`afet` to `atestasi`/`aasi`
- Fixed unnecessary clonning
- Removed unused `contract_addr_human` from State
- Implemented migration
- Added `wipe_all_roles_from_storage` from access_control